### PR TITLE
Added a setting to hide the new tweets pill

### DIFF
--- a/BHTManager.h
+++ b/BHTManager.h
@@ -65,6 +65,7 @@
 + (BOOL)disableMediaTab;
 + (BOOL)disableArticles;
 + (BOOL)hideCustomTimelines;
++ (BOOL)hideNewTweets;
 + (BOOL)hideTrends;
 + (BOOL)disableHighlights;
 

--- a/BHTManager.m
+++ b/BHTManager.m
@@ -298,7 +298,9 @@
 + (BOOL)hideTrends {
     return [[NSUserDefaults standardUserDefaults] boolForKey:@"hide_trends"];
 }
-
++ (BOOL)hideNewTweets {
+    return [[NSUserDefaults standardUserDefaults] boolForKey:@"hide_new_tweets"];
+}
 + (BOOL)disableHighlights {
     return [[NSUserDefaults standardUserDefaults] boolForKey:@"disableHighlights"];
 }

--- a/ModernSettingsViewController.m
+++ b/ModernSettingsViewController.m
@@ -2803,6 +2803,7 @@ if ([type isEqualToString:@"compactButton"]) {
         @{ @"key": @"hide_who_to_follow", @"titleKey": @"HIDE_WHO_FOLLOW_OPTION", @"subtitleKey": @"HIDE_WHO_FOLLOW_OPTION_DETAIL_TITLE", @"default": @YES },
         @{ @"key": @"hide_spaces", @"titleKey": @"HIDE_SPACE_OPTION_TITLE", @"subtitleKey": @"", @"default": @NO },
         @{ @"key": @"hide_custom_timelines", @"titleKey": @"HIDE_CUSTOM_TIMELINES_OPTION_TITLE", @"subtitleKey": @"HIDE_CUSTOM_TIMELINES_OPTION_DETAIL_TITLE", @"default": @NO },
+        @{ @"key": @"hide_new_tweets", @"titleKey": @"HIDE_NEW_TWEETS_OPTION_TITLE", @"subtitleKey": @"HIDE_NEW_TWEETS_OPTION_DETAIL_TITLE", @"default": @NO },
         @{ @"key": @"no_tab_bar_hiding", @"titleKey": @"STOP_HIDING_TAB_BAR_TITLE", @"subtitleKey": @"STOP_HIDING_TAB_BAR_DETAIL_TITLE", @"default": @YES },
         @{ @"key": @"tab_bar_theming", @"titleKey": @"CLASSIC_TAB_BAR_SETTINGS_TITLE", @"subtitleKey": @"CLASSIC_TAB_BAR_SETTINGS_DETAIL", @"default": @NO },
         @{ @"key": @"restore_tab_labels", @"titleKey": @"RESTORE_TAB_LABELS_TITLE", @"subtitleKey": @"RESTORE_TAB_LABELS_DETAIL", @"default": @NO },

--- a/Tweak.x
+++ b/Tweak.x
@@ -41,6 +41,12 @@
 @property(nonatomic) BOOL prefersEphemeralWebBrowserSession;
 @end
 
+@interface TFNPillControl : UIView
+@end
+
+@interface TFNPillTransformContainerView : UIView
+@end
+
 // Forward declarations
 static void BHT_UpdateAllTabBarIcons(void);
 static void BHT_applyThemeToWindow(UIWindow *window);
@@ -2992,6 +2998,38 @@ static NSNumber *BHTFeatureSwitchOverrideValueForKey(NSString *key) {
 
     return nil;
 }
+
+%hook TFNPillControl
+
+- (void)didMoveToSuperview {
+    %orig;
+
+    if (![BHTManager hideNewTweets]) {
+        return;
+    }
+
+    self.userInteractionEnabled = NO;
+    self.alpha = 0.0;
+}
+
+- (void)setHidden:(BOOL)hidden {
+    %orig(YES);
+}
+
+%end
+
+
+%hook TFNPillTransformContainerView
+
+- (void)setHidden:(BOOL)hidden {
+    if (![BHTManager hideNewTweets]) {
+        %orig(hidden);
+        return;
+    }
+    %orig(YES);
+}
+
+%end
 
 // MARK: Voice, SensitiveTweetWarnings, autoHighestLoad, VideoZoom, VODCaptions, disableSpacesBar feature
 %hook TPSTwitterFeatureSwitches

--- a/layout/Library/Application Support/BHT/BHTwitter.bundle/ar.lproj/Localizable.strings
+++ b/layout/Library/Application Support/BHT/BHTwitter.bundle/ar.lproj/Localizable.strings
@@ -36,6 +36,9 @@
 "HIDE_WHO_FOLLOW_OPTION" = "لا 'من تتابع'";
 "HIDE_WHO_FOLLOW_OPTION_DETAIL_TITLE" = "إخفاء اقتراحات المتابعة.";
 
+"HIDE_NEW_TWEETS_OPTION_TITLE" = "إخفاء التغريدات الجديدة";
+"HIDE_NEW_TWEETS_OPTION_DETAIL_TITLE" = "إخفاء الشريط الذي يظهر أعلى الشاشة عند توفر تغريدات جديدة.";
+
 "PADLOCK_OPTION_TITLE" = "قفل تويتر";
 "PADLOCK_OPTION_DETAIL_TITLE" = "يتطلب Face ID أو رمز مرور لفتح تويتر.";
 

--- a/layout/Library/Application Support/BHT/BHTwitter.bundle/de.lproj/Localizable.strings
+++ b/layout/Library/Application Support/BHT/BHTwitter.bundle/de.lproj/Localizable.strings
@@ -35,6 +35,10 @@
 "HIDE_WHO_FOLLOW_OPTION" = "Keine „Wem folgen?“";
 "HIDE_WHO_FOLLOW_OPTION_DETAIL_TITLE" = "Folge-Empfehlungen entfernen.";
 
+"HIDE_NEW_TWEETS_OPTION_TITLE" = "Keine neuen Tweets";
+"HIDE_NEW_TWEETS_OPTION_DETAIL_TITLE" = "Blendet die Leiste aus, die oben auf dem Bildschirm erscheint, wenn neue Tweets verfügbar sind.";
+
+
 "PADLOCK_OPTION_TITLE" = "Twitter sperren";
 "PADLOCK_OPTION_DETAIL_TITLE" = "Face ID oder einen Code verlangen, um Twitter zu öffnen.";
 

--- a/layout/Library/Application Support/BHT/BHTwitter.bundle/en.lproj/Localizable.strings
+++ b/layout/Library/Application Support/BHT/BHTwitter.bundle/en.lproj/Localizable.strings
@@ -88,6 +88,9 @@
 "NEW_INAPP_WEB_OPTION_TITLE" = "Improved in-app browser (beta)";
 "NEW_INAPP_WEB_DETAIL_TITLE" = "Use Twitter's new in-app browser for opening links.";
 
+"HIDE_NEW_TWEETS_OPTION_TITLE" = "Hide new tweets";
+"HIDE_NEW_TWEETS_OPTION_DETAIL_TITLE" = "Hides the bar that appears on the top of the screen when new tweets are available.";
+
 "ALWAYS_OPEN_SAFARI_OPTION_TITLE" = "Use external browser";
 "ALWAYS_OPEN_SAFARI_OPTION_DETAIL_TITLE" = "Open links in Safari or your default browser.";
 

--- a/layout/Library/Application Support/BHT/BHTwitter.bundle/es.lproj/Localizable.strings
+++ b/layout/Library/Application Support/BHT/BHTwitter.bundle/es.lproj/Localizable.strings
@@ -38,6 +38,10 @@
 "PADLOCK_OPTION_TITLE" = "Bloquear Twitter";
 "PADLOCK_OPTION_DETAIL_TITLE" = "Requiere Face ID o código para abrir Twitter.";
 
+"HIDE_NEW_TWEETS_OPTION_TITLE" = "Ocultar nuevos Tweets";
+"HIDE_NEW_TWEETS_OPTION_DETAIL_TITLE" = "Oculta la barra que aparece en la parte superior de la pantalla cuando hay nuevos Tweets disponibles.";
+
+
 "ALWAYS_OPEN_SAFARI_OPTION_TITLE" = "Usar navegador externo";
 "ALWAYS_OPEN_SAFARI_OPTION_DETAIL_TITLE" = "Abre enlaces en Safari o el navegador predeterminado.";
 

--- a/layout/Library/Application Support/BHT/BHTwitter.bundle/fr.lproj/Localizable.strings
+++ b/layout/Library/Application Support/BHT/BHTwitter.bundle/fr.lproj/Localizable.strings
@@ -35,6 +35,10 @@
 "HIDE_WHO_FOLLOW_OPTION" = "Pas de 'Qui suivre'";
 "HIDE_WHO_FOLLOW_OPTION_DETAIL_TITLE" = "Supprime les suggestions de suivi.";
 
+"HIDE_NEW_TWEETS_OPTION_TITLE" = "Pas de barre de nouveaux Tweets";
+"HIDE_NEW_TWEETS_OPTION_DETAIL_TITLE" = "Cache la barre qui apparaît en haut de l’écran quand de nouveaux Tweets sont disponibles.";
+
+
 "PADLOCK_OPTION_TITLE" = "Verrouiller Twitter";
 "PADLOCK_OPTION_DETAIL_TITLE" = "Nécessite Face ID ou un code pour ouvrir Twitter.";
 

--- a/layout/Library/Application Support/BHT/BHTwitter.bundle/hr.lproj/Localizable.strings
+++ b/layout/Library/Application Support/BHT/BHTwitter.bundle/hr.lproj/Localizable.strings
@@ -35,6 +35,10 @@
 "HIDE_WHO_FOLLOW_OPTION" = "Bez 'Koga pratiti'";
 "HIDE_WHO_FOLLOW_OPTION_DETAIL_TITLE" = "Ukloni prijedloge za praćenje iz profila.";
 
+"HIDE_NEW_TWEETS_OPTION_TITLE" = "Bez trake za nove tweetove";
+"HIDE_NEW_TWEETS_OPTION_DETAIL_TITLE" = "Sakrij traku koja se pojavljuje na vrhu zaslona kada su dostupni novi tweetovi.";
+
+
 "PADLOCK_OPTION_TITLE" = "Zaključaj Twitter";
 "PADLOCK_OPTION_DETAIL_TITLE" = "Za otvaranje Twittera potreban je Face ID ili šifra.";
 

--- a/layout/Library/Application Support/BHT/BHTwitter.bundle/id.lproj/Localizable.strings
+++ b/layout/Library/Application Support/BHT/BHTwitter.bundle/id.lproj/Localizable.strings
@@ -35,6 +35,10 @@
 "HIDE_WHO_FOLLOW_OPTION" = "Tanpa 'Siapa yang harus diikuti'";
 "HIDE_WHO_FOLLOW_OPTION_DETAIL_TITLE" = "Sembunyikan saran akun dari profil.";
 
+"HIDE_NEW_TWEETS_OPTION_TITLE" = "Tanpa bilah 'Tweet baru'";
+"HIDE_NEW_TWEETS_OPTION_DETAIL_TITLE" = "Sembunyikan bilah yang muncul di atas layar saat ada Tweet baru.";
+
+
 "PADLOCK_OPTION_TITLE" = "Kunci Twitter";
 "PADLOCK_OPTION_DETAIL_TITLE" = "Butuh Face ID atau kode untuk membuka Twitter.";
 

--- a/layout/Library/Application Support/BHT/BHTwitter.bundle/ja.lproj/Localizable.strings
+++ b/layout/Library/Application Support/BHT/BHTwitter.bundle/ja.lproj/Localizable.strings
@@ -88,6 +88,9 @@
 "NEW_INAPP_WEB_OPTION_TITLE" = "アプリ内ブラウザを改善(ベータ版)";
 "NEW_INAPP_WEB_DETAIL_TITLE" = "リンクを開く際に、Twitterの新しいアプリ内ブラウザを使用します。";
 
+"HIDE_NEW_TWEETS_OPTION_TITLE" = "新しいツイートを非表示にする";
+"HIDE_NEW_TWEETS_OPTION_DETAIL_TITLE" = "新しいツイートがあるときに画面上部に表示されるバーを非表示にします。";
+
 "ALWAYS_OPEN_SAFARI_OPTION_TITLE" = "外部ブラウザを使用";
 "ALWAYS_OPEN_SAFARI_OPTION_DETAIL_TITLE" = "Safariまたはデフォルトのブラウザでリンクを開きます。";
 

--- a/layout/Library/Application Support/BHT/BHTwitter.bundle/ko.lproj/Localizable.strings
+++ b/layout/Library/Application Support/BHT/BHTwitter.bundle/ko.lproj/Localizable.strings
@@ -88,6 +88,9 @@
 "NEW_INAPP_WEB_OPTION_TITLE" = "개선된 인앱 브라우저 (베타)";
 "NEW_INAPP_WEB_DETAIL_TITLE" = "링크를 열 때 트위터의 새 인앱 브라우저를 사용합니다.";
 
+"HIDE_NEW_TWEETS_OPTION_TITLE" = "새 트윗 숨기기";
+"HIDE_NEW_TWEETS_OPTION_DETAIL_TITLE" = "새로운 트윗이 있을 때 화면 상단에 표시되는 바를 숨깁니다.";
+
 "ALWAYS_OPEN_SAFARI_OPTION_TITLE" = "인앱 브라우저 끄기";
 "ALWAYS_OPEN_SAFARI_OPTION_DETAIL_TITLE" = "링크를 Safari나 사용자의 기본 브라우저로 엽니다.";
 

--- a/layout/Library/Application Support/BHT/BHTwitter.bundle/pl.lproj/Localizable.strings
+++ b/layout/Library/Application Support/BHT/BHTwitter.bundle/pl.lproj/Localizable.strings
@@ -36,6 +36,9 @@
 "PADLOCK_OPTION_TITLE" = "Zablokuj Twittera";
 "PADLOCK_OPTION_DETAIL_TITLE" = "Wymagaj Face ID lub kodu, aby otworzyć Twittera.";
 
+"HIDE_NEW_TWEETS_OPTION_TITLE" = "Ukryj nowe tweety";
+"HIDE_NEW_TWEETS_OPTION_DETAIL_TITLE" = "Ukrywa pasek wyświetlany u góry ekranu, gdy pojawiają się nowe tweety.";
+
 "NEW_INAPP_WEB_OPTION_TITLE" = "Ulepszona przeglądarka w aplikacji (beta)";
 "NEW_INAPP_WEB_DETAIL_TITLE" = "Używaj nowej przeglądarki w aplikacji do otwierania linków.";
 

--- a/layout/Library/Application Support/BHT/BHTwitter.bundle/ru.lproj/Localizable.strings
+++ b/layout/Library/Application Support/BHT/BHTwitter.bundle/ru.lproj/Localizable.strings
@@ -35,6 +35,9 @@
 "HIDE_WHO_FOLLOW_OPTION" = "Без «Кого читать»";
 "HIDE_WHO_FOLLOW_OPTION_DETAIL_TITLE" = "Убрать рекомендации из профилей.";
 
+"HIDE_NEW_TWEETS_OPTION_TITLE" = "Скрыть новые твиты";
+"HIDE_NEW_TWEETS_OPTION_DETAIL_TITLE" = "Скрывает панель, которая появляется в верхней части экрана при появлении новых твитов.";
+
 "PADLOCK_OPTION_TITLE" = "Заблокировать Twitter";
 "PADLOCK_OPTION_DETAIL_TITLE" = "Требуется Face ID или пароль для входа.";
 

--- a/layout/Library/Application Support/BHT/BHTwitter.bundle/sv.lproj/Localizable.strings
+++ b/layout/Library/Application Support/BHT/BHTwitter.bundle/sv.lproj/Localizable.strings
@@ -37,6 +37,9 @@
 "HIDE_WHO_FOLLOW_OPTION" = "Ingen ’Vem att följa’";
 "HIDE_WHO_FOLLOW_OPTION_DETAIL_TITLE" = "Ta bort förslag om vem du kan följa från profiler.";
 
+"HIDE_NEW_TWEETS_OPTION_TITLE" = "Dölj nya tweets";
+"HIDE_NEW_TWEETS_OPTION_DETAIL_TITLE" = "Döljer fältet som visas längst upp på skärmen när det finns nya tweets.";
+
 "PADLOCK_OPTION_TITLE" = "Lås Twitter";
 "PADLOCK_OPTION_DETAIL_TITLE" = "Kräv Face ID eller lösenkod för att öppna Twitter.";
 

--- a/layout/Library/Application Support/BHT/BHTwitter.bundle/tr.lproj/Localizable.strings
+++ b/layout/Library/Application Support/BHT/BHTwitter.bundle/tr.lproj/Localizable.strings
@@ -38,6 +38,9 @@
 "PADLOCK_OPTION_TITLE" = "Twitter’ı kilitle";
 "PADLOCK_OPTION_DETAIL_TITLE" = "Açmak için Face ID veya şifre iste.";
 
+"HIDE_NEW_TWEETS_OPTION_TITLE" = "Yeni tweetleri gizle";
+"HIDE_NEW_TWEETS_OPTION_DETAIL_TITLE" = "Yeni tweetler geldiğinde ekranın üst kısmında görünen çubuğu gizler.";
+
 "ALWAYS_OPEN_SAFARI_OPTION_TITLE" = "Harici tarayıcı kullan";
 "ALWAYS_OPEN_SAFARI_OPTION_DETAIL_TITLE" = "Linkleri Safari veya varsayılan tarayıcıda aç.";
 

--- a/layout/Library/Application Support/BHT/BHTwitter.bundle/uk.lproj/Localizable.strings
+++ b/layout/Library/Application Support/BHT/BHTwitter.bundle/uk.lproj/Localizable.strings
@@ -40,6 +40,9 @@
 "PADLOCK_OPTION_TITLE" = "Заблокувати Twitter";
 "PADLOCK_OPTION_DETAIL_TITLE" = "Потрібен Face ID або пароль для входу.";
 
+"HIDE_NEW_TWEETS_OPTION_TITLE" = "Приховати нові твіти";
+"HIDE_NEW_TWEETS_OPTION_DETAIL_TITLE" = "Приховує панель, яка з’являється у верхній частині екрана, коли з’являються нові твіти.";
+
 "ALWAYS_OPEN_SAFARI_OPTION_TITLE" = "Відкривати у браузері";
 "ALWAYS_OPEN_SAFARI_OPTION_DETAIL_TITLE" = "Відкривати посилання в Safari або браузері за замовчуванням.";
 

--- a/layout/Library/Application Support/BHT/BHTwitter.bundle/zh-Hant.lproj/Localizable.strings
+++ b/layout/Library/Application Support/BHT/BHTwitter.bundle/zh-Hant.lproj/Localizable.strings
@@ -85,6 +85,9 @@
 "PADLOCK_OPTION_TITLE" = "鎖定 Twitter";
 "PADLOCK_OPTION_DETAIL_TITLE" = "開啟時需使用 Face ID 或密碼。";
 
+"HIDE_NEW_TWEETS_OPTION_TITLE" = "隱藏新推文";
+"HIDE_NEW_TWEETS_OPTION_DETAIL_TITLE" = "隱藏當有新推文時會出現在螢幕頂端的工具列。";
+
 "NEW_INAPP_WEB_OPTION_TITLE" = "改良版內建瀏覽器 (測試版)";
 "NEW_INAPP_WEB_DETAIL_TITLE" = "使用 Twitter 新版內建瀏覽器開啟連結。";
 

--- a/layout/Library/Application Support/BHT/BHTwitter.bundle/zh_CN.lproj/Localizable.strings
+++ b/layout/Library/Application Support/BHT/BHTwitter.bundle/zh_CN.lproj/Localizable.strings
@@ -38,6 +38,9 @@
 "PADLOCK_OPTION_TITLE" = "锁定 Twitter";
 "PADLOCK_OPTION_DETAIL_TITLE" = "启用 Face ID 或密码解锁 Twitter。";
 
+"HIDE_NEW_TWEETS_OPTION_TITLE" = "隐藏新推文";
+"HIDE_NEW_TWEETS_OPTION_DETAIL_TITLE" = "隐藏在有新推文时出现在屏幕顶部的提示栏。";
+
 "ALWAYS_OPEN_SAFARI_OPTION_TITLE" = "使用外部浏览器";
 "ALWAYS_OPEN_SAFARI_OPTION_DETAIL_TITLE" = "在 Safari 或默认浏览器中打开链接。";
 


### PR DESCRIPTION
Finds the TFNControlPill class and sets its alpha to 0, making it essentially invisible, with no area to interact with for errand clicks.

Tested on version 12.5.1 of the X app on iOS 26.5