### PR TITLE
Added true gif downloading

### DIFF
--- a/BHDownload/BHDownload.m
+++ b/BHDownload/BHDownload.m
@@ -37,9 +37,13 @@
     [delegate downloadDidFinish:location Filename:self.fileName];
 }
 - (void)URLSession:(NSURLSession *)session didBecomeInvalidWithError:(NSError *)error {
-    [delegate downloadDidFailureWithError:error];
+    if (error != nil) {
+        [delegate downloadDidFailureWithError:error];
+    }
 }
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error {
-    [delegate downloadDidFailureWithError:error];
+    if (error != nil) {
+        [delegate downloadDidFailureWithError:error];
+    }
 }
 @end

--- a/BHDownloadInlineButton.m
+++ b/BHDownloadInlineButton.m
@@ -20,13 +20,36 @@ static inline UIViewController *BHTopMostController(void) {
 #pragma mark - BHDownloadInlineButton
 @interface BHDownloadInlineButton () <BHDownloadDelegate>
 @property (nonatomic, strong) JGProgressHUD *hud;
+@property (nonatomic, assign) BOOL bht_isGIFDownload;
 @end
 
 @implementation BHDownloadInlineButton
 
+- (void)bht_presentDownloadFailureAlertWithMessage:(NSString *)message {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.hud dismiss];
+
+        UIAlertController *alert = [UIAlertController alertControllerWithTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"ERROR_TITLE"]
+                                                                       message:message ?: [[BHTBundle sharedBundle] localizedStringForKey:@"UNKNOWN_ERROR"]
+                                                                preferredStyle:UIAlertControllerStyleAlert];
+        [alert addAction:[UIAlertAction actionWithTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"OK_BUTTON"]
+                                                  style:UIAlertActionStyleDefault
+                                                handler:nil]];
+        [BHTopMostController() presentViewController:alert animated:YES completion:nil];
+
+        if (@available(iOS 10.0, *)) {
+            UINotificationFeedbackGenerator *g = [UINotificationFeedbackGenerator new];
+            [g prepare];
+            [g notificationOccurred:UINotificationFeedbackTypeError];
+        }
+    });
+}
+
 #pragma mark ••• Download handler
 - (void)presentDownloadOptionsForMediaEntities:(NSArray *)mediaEntities {
     @try {
+        self.bht_isGIFDownload = NO;
+
         NSAttributedString *titleString = [[NSAttributedString alloc] initWithString:[[BHTBundle sharedBundle] localizedStringForKey:@"DOWNLOAD_MENU_TITLE"]
                                                                          attributes:@{ NSFontAttributeName : [BHTManager menuTitleFont],
                                                                                        NSForegroundColorAttributeName : UIColor.labelColor }];
@@ -45,9 +68,11 @@ static inline UIViewController *BHTopMostController(void) {
         void (^dismissHUD)(void) = ^{ [self.hud dismiss]; };
 
         // Variant builders
-        TFNActionItem* (^makeMP4Item)(NSURL *) = ^TFNActionItem*(NSURL *url) {
-            return [objc_getClass("TFNActionItem") actionItemWithTitle:[BHTManager getVideoQuality:url.absoluteString]
+        TFNActionItem* (^makeMP4Item)(NSURL *, BOOL) = ^TFNActionItem*(NSURL *url, BOOL isGIF) {
+            NSString *title = isGIF ? @"GIF" : [BHTManager getVideoQuality:url.absoluteString];
+            return [objc_getClass("TFNActionItem") actionItemWithTitle:title
                                                                imageName:@"arrow_down_circle_stroke" action:^{
+                self.bht_isGIFDownload = isGIF;
                 BHDownload *dwManager = [[BHDownload alloc] init];
                 [dwManager setDelegate:self];
                 [dwManager downloadFileWithURL:url];
@@ -55,9 +80,10 @@ static inline UIViewController *BHTopMostController(void) {
             }];
         };
 
-        TFNActionItem* (^makeM3U8Item)(NSURL *) = ^TFNActionItem*(NSURL *url) {
+        TFNActionItem* (^makeM3U8Item)(NSURL *, BOOL) = ^TFNActionItem*(NSURL *url, BOOL isGIF) {
             return [objc_getClass("TFNActionItem") actionItemWithTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"FFMPEG_DOWNLOAD_OPTION_TITLE"]
                                                                imageName:@"arrow_down_circle_stroke" action:^{
+                self.bht_isGIFDownload = isGIF;
                 startHUD(@"FETCHING_PROGRESS_TITLE");
                 dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
                     MediaInformation *info = [BHTManager getM3U8Information:url];
@@ -73,12 +99,14 @@ static inline UIViewController *BHTopMostController(void) {
         // Media enumeration
         if (mediaEntities.count > 1) {
             [mediaEntities enumerateObjectsUsingBlock:^(TFSTwitterEntityMedia *obj, NSUInteger idx, BOOL *stop) {
+                BOOL isGIF = (obj.mediaType == 2);
                 if (obj.mediaType == 2 || obj.mediaType == 3) {
-                    TFNActionItem *videoGroup = [objc_getClass("TFNActionItem") actionItemWithTitle:[NSString stringWithFormat:@"Video %lu", (unsigned long)idx + 1]
+                    NSString *groupTitle = isGIF ? @"GIF" : [NSString stringWithFormat:@"Video %lu", (unsigned long)idx + 1];
+                    TFNActionItem *videoGroup = [objc_getClass("TFNActionItem") actionItemWithTitle:groupTitle
                                                                                        imageName:@"arrow_down_circle_stroke" action:^{
                         for (TFSTwitterEntityMediaVideoVariant *variant in obj.videoInfo.variants) {
-                            if ([variant.contentType isEqualToString:@"video/mp4"])          [innerActions addObject:makeMP4Item([NSURL URLWithString:variant.url])];
-                            if ([variant.contentType isEqualToString:@"application/x-mpegURL"]) [innerActions addObject:makeM3U8Item([NSURL URLWithString:variant.url])];
+                            if ([variant.contentType isEqualToString:@"video/mp4"])          [innerActions addObject:makeMP4Item([NSURL URLWithString:variant.url], isGIF)];
+                            if ([variant.contentType isEqualToString:@"application/x-mpegURL"]) [innerActions addObject:makeM3U8Item([NSURL URLWithString:variant.url], isGIF)];
                         }
                         TFNMenuSheetViewController *inner = [[objc_getClass("TFNMenuSheetViewController") alloc] initWithActionItems:innerActions.copy];
                         [inner tfnPresentedCustomPresentFromViewController:BHTopMostController() animated:YES completion:nil];
@@ -88,9 +116,10 @@ static inline UIViewController *BHTopMostController(void) {
             }];
         } else if (mediaEntities.firstObject) {
             TFSTwitterEntityMedia *first = mediaEntities.firstObject;
+            BOOL isGIF = (first.mediaType == 2);
             for (TFSTwitterEntityMediaVideoVariant *variant in first.videoInfo.variants) {
-                if ([variant.contentType isEqualToString:@"video/mp4"])          [actions addObject:makeMP4Item([NSURL URLWithString:variant.url])];
-                if ([variant.contentType isEqualToString:@"application/x-mpegURL"]) [actions addObject:makeM3U8Item([NSURL URLWithString:variant.url])];
+                if ([variant.contentType isEqualToString:@"video/mp4"])          [actions addObject:makeMP4Item([NSURL URLWithString:variant.url], isGIF)];
+                if ([variant.contentType isEqualToString:@"application/x-mpegURL"]) [actions addObject:makeM3U8Item([NSURL URLWithString:variant.url], isGIF)];
             }
         }
 
@@ -113,40 +142,72 @@ static inline UIViewController *BHTopMostController(void) {
 - (void)downloadDidFinish:(NSURL *)tmpURL Filename:(NSString *)name {
     NSString *doc = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
     NSURL *dst = [[NSURL fileURLWithPath:doc]
-                  URLByAppendingPathComponent:[NSString stringWithFormat:@"%@.mp4", NSUUID.UUID.UUIDString]];
+                  URLByAppendingPathComponent:[NSString stringWithFormat:@"%@.%@", NSUUID.UUID.UUIDString, self.bht_isGIFDownload ? @"gif" : @"mp4"]];
 
-    [[NSFileManager defaultManager] moveItemAtURL:tmpURL toURL:dst error:nil];
-
-    if (![BHTManager DirectSave]) {
-        [self.hud dismiss];
-        [BHTManager showSaveVC:dst];
-    } else {
-        if (@available(iOS 10.0, *)) {
-            UINotificationFeedbackGenerator *g = [UINotificationFeedbackGenerator new];
-            [g prepare];
-            [g notificationOccurred:UINotificationFeedbackTypeSuccess];
+    if (!self.bht_isGIFDownload) {
+        NSError *copyError = nil;
+        [[NSFileManager defaultManager] copyItemAtURL:tmpURL toURL:dst error:&copyError];
+        if (copyError) {
+            [self bht_presentDownloadFailureAlertWithMessage:copyError.localizedDescription];
+            return;
         }
-        [BHTManager save:dst];
+
+        if (![BHTManager DirectSave]) {
+            [self.hud dismiss];
+            [BHTManager showSaveVC:dst];
+        } else {
+            [BHTManager save:dst];
+        }
+        return;
     }
+
+    // URLSession only guarantees tmpURL exists for the duration of this delegate
+    // callback; it deletes it as soon as we return. FFmpegKit's executor runs
+    // asynchronously on a later run-loop turn, so we must stage the file at a
+    // stable path first, or ffmpeg finds nothing at -i.
+    NSURL *stagedInput = [[NSURL fileURLWithPath:NSTemporaryDirectory()]
+                          URLByAppendingPathComponent:[NSString stringWithFormat:@"%@.mp4", NSUUID.UUID.UUIDString]];
+    NSError *stageError = nil;
+    [[NSFileManager defaultManager] copyItemAtURL:tmpURL toURL:stagedInput error:&stageError];
+    if (stageError) {
+        [self bht_presentDownloadFailureAlertWithMessage:stageError.localizedDescription];
+        return;
+    }
+
+    self.hud.textLabel.text = @"Converting GIF";
+    NSString *inputPath = stagedInput.path;
+    NSString *outputPath = dst.path;
+    NSString *command = [NSString stringWithFormat:@"-y -i \"%@\" -filter_complex \"[0:v]fps=15,scale=trunc(iw/2)*2:trunc(ih/2)*2:flags=lanczos,split[a][b];[a]palettegen[p];[b][p]paletteuse=dither=bayer:bayer_scale=5\" -loop 0 \"%@\"", inputPath, outputPath];
+
+    [FFmpegKit executeAsync:command withCompleteCallback:^(FFmpegSession *session) {
+        ReturnCode *returnCode = [session getReturnCode];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[NSFileManager defaultManager] removeItemAtURL:stagedInput error:nil];
+            BOOL exists = [[NSFileManager defaultManager] fileExistsAtPath:dst.path];
+            if ([ReturnCode isSuccess:returnCode] && exists) {
+                [self.hud dismiss];
+                if ([BHTManager DirectSave]) {
+                    [BHTManager save:dst];
+                } else {
+                    [BHTManager showSaveVC:dst];
+                }
+            } else {
+                [self bht_presentDownloadFailureAlertWithMessage:@"GIF conversion failed. Please try again."];
+            }
+        });
+    }];
 }
 
 - (void)downloadDidFailureWithError:(NSError *)error {
-    [self.hud dismiss];
-    if (!error) return;
+    NSLog(@"BHDownload failed: %@", error);
+    NSLog(@"Domain: %@ Code: %ld UserInfo: %@",
+          error.domain,
+          (long)error.code,
+          error.userInfo);
 
-    UIAlertController *a = [UIAlertController alertControllerWithTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"ERROR_TITLE"]
-                                                               message:error.localizedDescription
-                                                        preferredStyle:UIAlertControllerStyleAlert];
-    [a addAction:[UIAlertAction actionWithTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"OK_BUTTON"]
-                                          style:UIAlertActionStyleDefault
-                                        handler:nil]];
-    [BHTopMostController() presentViewController:a animated:YES completion:nil];
+    NSString *errorMessage = [NSString stringWithFormat:@"Error Code: %ld\nDescription: %@", (long)error.code, error.localizedDescription];
 
-    if (@available(iOS 10.0, *)) {
-        UINotificationFeedbackGenerator *g = [UINotificationFeedbackGenerator new];
-        [g prepare];
-        [g notificationOccurred:UINotificationFeedbackTypeError];
-    }
+    [self bht_presentDownloadFailureAlertWithMessage:errorMessage];
 }
 
 @end

--- a/BHTManager.m
+++ b/BHTManager.m
@@ -24,6 +24,9 @@
         if ([file.pathExtension.lowercaseString isEqualToString:@"mp4"]) {
             [[NSFileManager defaultManager] removeItemAtURL:file error:nil];
         }
+        if ([file.pathExtension.lowercaseString isEqualToString:@"gif"]) {
+            [[NSFileManager defaultManager] removeItemAtURL:file error:nil];
+        }
     }
 
     NSArray <NSURL *> *TempFiles = [[NSFileManager defaultManager] contentsOfDirectoryAtURL:[NSURL fileURLWithPath:NSTemporaryDirectory()] includingPropertiesForKeys:@[] options:NSDirectoryEnumerationSkipsHiddenFiles error:nil];
@@ -99,6 +102,13 @@
     return isMediaEntityVideo || isGIF;
 }
 + (void)save:(NSURL *)url {
+    if ([url.pathExtension.lowercaseString isEqualToString:@"gif"]) {
+        [[PHPhotoLibrary sharedPhotoLibrary] performChangesAndWait:^{
+            [PHAssetChangeRequest creationRequestForAssetFromImageAtFileURL:url];
+        } error:nil];
+        return;
+    }
+
     [[PHPhotoLibrary sharedPhotoLibrary] performChangesAndWait:^{
         [PHAssetChangeRequest creationRequestForAssetFromVideoAtFileURL:url];
     } error:nil];

--- a/Tweak.x
+++ b/Tweak.x
@@ -1230,6 +1230,10 @@ static void BHTApplyCopyButtonStyle(UIButton *copyButton, T1ProfileHeaderView *h
 %end
 
 // MARK: DM download
+@interface T1DirectMessageEntryMediaCell ()
+@property (nonatomic, assign) BOOL bht_isGIFDownload;
+@end
+
 %hook T1DirectMessageEntryMediaCell
 %property (nonatomic, strong) JGProgressHUD *hud;
 - (void)setEntryViewModel:(id)arg1 {
@@ -1262,12 +1266,15 @@ static void BHTApplyCopyButtonStyle(UIButton *copyButton, T1ProfileHeaderView *h
     [actions addObject:title];
 
     T1PlayerMediaEntitySessionProducible *session = self.inlineMediaView.viewModel.playerSessionProducer.sessionProducible;
+    BOOL isGIF = session.mediaEntity.mediaType == 2;
     for (TFSTwitterEntityMediaVideoVariant *i in session.mediaEntity.videoInfo.variants) {
         if ([i.contentType isEqualToString:@"video/mp4"]) {
-            TFNActionItem *download = [%c(TFNActionItem) actionItemWithTitle:[BHTManager getVideoQuality:i.url] imageName:@"arrow_down_circle_stroke" action:^{
+            NSString *downloadTitle = isGIF ? @"GIF" : [BHTManager getVideoQuality:i.url];
+            TFNActionItem *download = [%c(TFNActionItem) actionItemWithTitle:downloadTitle imageName:@"arrow_down_circle_stroke" action:^{
                 BHDownload *DownloadManager = [[BHDownload alloc] init];
                 self.hud = [JGProgressHUD progressHUDWithStyle:JGProgressHUDStyleDark];
                 self.hud.textLabel.text = [[BHTBundle sharedBundle] localizedStringForKey:@"PROGRESS_DOWNLOADING_STATUS_TITLE"];
+                self.bht_isGIFDownload = isGIF;
                 [DownloadManager downloadFileWithURL:[NSURL URLWithString:i.url]];
                 [DownloadManager setDelegate:self];
                 [self.hud showInView:topMostController().view];
@@ -1308,10 +1315,52 @@ static void BHTApplyCopyButtonStyle(UIButton *copyButton, T1ProfileHeaderView *h
 %new - (void)downloadDidFinish:(NSURL *)filePath Filename:(NSString *)fileName {
     NSString *DocPath = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, true).firstObject;
     NSFileManager *manager = [NSFileManager defaultManager];
-    NSURL *newFilePath = [[NSURL fileURLWithPath:DocPath] URLByAppendingPathComponent:[NSString stringWithFormat:@"%@.mp4", NSUUID.UUID.UUIDString]];
-    [manager moveItemAtURL:filePath toURL:newFilePath error:nil];
-    [self.hud dismiss];
-    [BHTManager showSaveVC:newFilePath];
+    NSString *extension = self.bht_isGIFDownload ? @"gif" : @"mp4";
+    NSURL *newFilePath = [[NSURL fileURLWithPath:DocPath] URLByAppendingPathComponent:[NSString stringWithFormat:@"%@.%@", NSUUID.UUID.UUIDString, extension]];
+
+    if (!self.bht_isGIFDownload) {
+        [manager moveItemAtURL:filePath toURL:newFilePath error:nil];
+        [self.hud dismiss];
+        if ([BHTManager DirectSave]) {
+            [BHTManager save:newFilePath];
+        } else {
+            [BHTManager showSaveVC:newFilePath];
+        }
+        return;
+    }
+
+    // Stage the session file first; the download temp URL is only guaranteed to
+    // exist for the duration of this callback.
+    NSURL *stagedInput = [[NSURL fileURLWithPath:NSTemporaryDirectory()]
+                          URLByAppendingPathComponent:[NSString stringWithFormat:@"%@.mp4", NSUUID.UUID.UUIDString]];
+    NSError *stageError = nil;
+    [manager moveItemAtURL:filePath toURL:stagedInput error:&stageError];
+    if (stageError) {
+        [self.hud dismiss];
+        return;
+    }
+
+    self.hud.textLabel.text = @"Converting GIF";
+    NSString *inputPath = stagedInput.path;
+    NSString *outputPath = newFilePath.path;
+    NSString *command = [NSString stringWithFormat:@"-y -i \"%@\" -filter_complex \"[0:v]fps=15,scale=trunc(iw/2)*2:trunc(ih/2)*2:flags=lanczos,split[a][b];[a]palettegen[p];[b][p]paletteuse=dither=bayer:bayer_scale=5\" -loop 0 \"%@\"", inputPath, outputPath];
+
+    [FFmpegKit executeAsync:command withCompleteCallback:^(FFmpegSession *session) {
+        ReturnCode *returnCode = [session getReturnCode];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [manager removeItemAtURL:stagedInput error:nil];
+            if ([ReturnCode isSuccess:returnCode]) {
+                [self.hud dismiss];
+                if ([BHTManager DirectSave]) {
+                    [BHTManager save:newFilePath];
+                } else {
+                    [BHTManager showSaveVC:newFilePath];
+                }
+            } else {
+                [self.hud dismiss];
+            }
+        });
+    }];
 }
 %new - (void)downloadDidFailureWithError:(NSError *)error {
     if (error) {


### PR DESCRIPTION
Used the ffmpeg binary inside the app to convert GIFs downloaded from Twitter (since they have a media-type of 2) from MP4s to GIFs at 15fps (since Twitter caps the FPS). Also added the changes to GIFs downloaded in DMs.

Tested on version 12.7 of the X app on iOS 26.5.