### PR TITLE
Hides Grok Button in tweet composer

### DIFF
--- a/Tweak.x
+++ b/Tweak.x
@@ -4927,6 +4927,19 @@ static BOOL BHColorTwitterIconEnabled(void) {
 }
 %end
 
+// MARK: - Hide Grok Button in Tweet Composer
+%hook TFNButtonBarView
+- (void)setLeadingViews:(NSArray *)leadingViews {
+    if ([BHTManager hideGrokAnalyze] && leadingViews.count) {
+        NSPredicate *notGrokButton = [NSPredicate predicateWithBlock:^BOOL(UIView *view, NSDictionary *bindings) {
+            return ![view.accessibilityIdentifier isEqualToString:@"GrokButton"];
+        }];
+        leadingViews = [leadingViews filteredArrayUsingPredicate:notGrokButton];
+    }
+    %orig(leadingViews);
+}
+%end
+
 %hook TFSTwitterStatus
 - (BOOL)grokAnalysisButton {
     if ([BHTManager hideGrokAnalyze]) return NO;


### PR DESCRIPTION
Extends the “Hide Grok” setting to hide it from the tweet composer when the setting is toggled on. Finds the leading views for the UIView which holds the buttons for additional tasks and filters out the button with Grok (has an accessibility identifier).