### PR TITLE
Added dim theme

### DIFF
--- a/layout/Library/Application Support/BHT/BHTwitter.bundle/en.lproj/Localizable.strings
+++ b/layout/Library/Application Support/BHT/BHTwitter.bundle/en.lproj/Localizable.strings
@@ -263,6 +263,13 @@
 "RESTORE_TWITTER_NAMES_TITLE" = "Restore Twitter terminology";
 "RESTORE_TWITTER_NAMES_DETAIL" = "Replaces 'X' with 'Twitter', 'Post' with 'Tweet', 'Repost' with 'Retweet' and so on throughout the app's interface.";
 
+/*Dim Theme*/
+"ENABLE_DIM_THEME_TITLE" = "Enable dim theme";
+"ENABLE_DIM_THEME_DETAIL" = "Restores the removed dim theme for Twitter. Requires dark mode to be enabled and a restart.";
+"DIM_THEME_RESTART_ALERT_TITLE" = "Restart required";
+"DIM_THEME_RESTART_ALERT_MESSAGE" = "The dim theme requires a restart to take effect.";
+"DIM_THEME_RESTART_ALERT_RESTART_BUTTON" = "Restart";
+
 /*Deprecated*/
 "MODERN_SETTINGS_PLACEHOLDER_TEXT" = "Nothing to see here - yet";
 "MODERN_SETTINGS_PLACEHOLDER_DETAIL_TEXT" = "This section is coming soon. Stay tuned for more NeoFreeBird features!";

--- a/src/Core/BHTSettings.m
+++ b/src/Core/BHTSettings.m
@@ -55,6 +55,8 @@ static NSDictionary<NSString*, NSDictionary*>* BHTSettingsPages(void) {
                       @"default": @NO},
                     @{@"key": @"restore_tab_labels",
                       @"default": @NO},
+                    @{@"key": @"enable_dim_theme",
+                      @"default": @NO},
                     @{@"key": @"custom_fonts",
                       @"default": @NO},
                     @{

--- a/src/Headers/Helpers.h
+++ b/src/Headers/Helpers.h
@@ -40,24 +40,6 @@ static UIImage* imageFromView(UIView* view) {
     return img;
 }
 
-static UIFont* _Nullable getDefaultFont(UIFont* font) {
-    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"custom_fonts"]) {
-        // https://stackoverflow.com/a/20515367/16619237
-        UIFontDescriptorSymbolicTraits fontDescriptorSymbolicTraits =
-            font.fontDescriptor.symbolicTraits;
-        BOOL isBold =
-            (fontDescriptorSymbolicTraits & UIFontDescriptorTraitBold) != 0;
-
-        if ([[NSUserDefaults standardUserDefaults]
-                objectForKey:isBold ? @"bhtwitter_font_2" : @"bhtwitter_font_1"]) {
-            NSString* fontName = [[NSUserDefaults standardUserDefaults]
-                objectForKey:isBold ? @"bhtwitter_font_2" : @"bhtwitter_font_1"];
-            return [UIFont fontWithName:fontName size:font.pointSize];
-        }
-        return nil;
-    }
-    return nil;
-}
 static BOOL isDeviceLanguageRTL() {
     return [NSParagraphStyle _defaultWritingDirection] ==
            NSWritingDirectionRightToLeft;

--- a/src/Headers/TFNHeaders.h
+++ b/src/Headers/TFNHeaders.h
@@ -35,6 +35,9 @@
 @interface TFNNavigationController : UINavigationController
 @end
 
+@interface TFNNavigationBar : UINavigationBar
+@end
+
 @interface TFNActionItem : NSObject
 + (instancetype)cancelActionItemWithAction:(void (^)(void))arg1;
 + (instancetype)cancelActionItemWithTitle:(NSString*)arg1;
@@ -132,6 +135,10 @@
 @interface TFNTitleView : UIView
 + (instancetype)titleViewWithTitle:(NSString*)title
                           subtitle:(NSString*)subTitle;
+@end
+
+@interface TFNSolidColorView : UIView
+@property (nonatomic, strong) UIColor* backgroundColor;
 @end
 
 @interface UIImage (TFNAdditions)

--- a/src/Headers/UIHeaders.h
+++ b/src/Headers/UIHeaders.h
@@ -1,0 +1,20 @@
+//
+//  UIHeaders.h
+//  NeoFreeBird
+//
+//  Created by orionblur
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UIDynamicSystemColor : UIColor
+@end
+
+@interface UIDynamicCatalogColor : UIColor
+@end
+
+@interface UIExtendedSRGBColorSpace : UIColor
+@end
+
+@interface UIDeviceRGBColor: UIColor
+@end

--- a/src/Hooks/HookHelpers.h
+++ b/src/Hooks/HookHelpers.h
@@ -25,6 +25,7 @@
 #import "LegacyLogin/LegacyLoginViewController.h"
 #import "Padlock/AuthViewController.h"
 #import "Settings/ModernSettingsViewController.h"
+#import "ThemeColor/BHTDimPalette.h"
 #import "ThemeColor/Palette.h"
 
 // Recursive view traversal (BHTHookHelpers.m)

--- a/src/Hooks/Settings.x
+++ b/src/Hooks/Settings.x
@@ -5,11 +5,6 @@
 
 #import "HookHelpers.h"
 
-static UIFont* _Nonnull remapFont(UIFont* origFont) {
-    UIFont* newFont = getDefaultFont(origFont);
-    return newFont != nil ? newFont : origFont;
-}
-
 // MARK: - NeoFreeBird settings entry
 
 static const void* SettingsEntryKey = &SettingsEntryKey;
@@ -252,28 +247,22 @@ static NSArray* sectionsWithNeoFreeBirdEntry(TFNItemsDataViewController* setting
 }
 %end
 
-// Every named getter (bodyFont, title1Font, ...) dispatches to one of these five
-// methods, the only ones that actually build a UIFont; remapping here covers all.
-%hook TFNUIDefaultFontGroup
-- (UIFont*)fontOfSize:(CGFloat)size {
+%hook UIFont
++ (UIFont*)tfn_fontWithName:(NSString*)name size:(CGFloat)size {
     UIFont* origFont = %orig;
-    return remapFont(origFont);
-}
-- (UIFont*)mediumFontOfSize:(CGFloat)size {
-    UIFont* origFont = %orig;
-    return remapFont(origFont);
-}
-- (UIFont*)boldFontOfSize:(CGFloat)size {
-    UIFont* origFont = %orig;
-    return remapFont(origFont);
-}
-- (UIFont*)heavyFontOfSize:(CGFloat)size {
-    UIFont* origFont = %orig;
-    return remapFont(origFont);
-}
-- (UIFont*)monospacedDigitFontOfSize:(CGFloat)size weight:(CGFloat)weight {
-    UIFont* origFont = %orig;
-    return remapFont(origFont);
+
+    if (![[NSUserDefaults standardUserDefaults] boolForKey:@"custom_fonts"]) {
+        return origFont;
+    }
+
+    BOOL isBold = [name containsString:@"Bold"] || [name containsString:@"Heavy"];
+    NSString* customName = [[NSUserDefaults standardUserDefaults]
+        objectForKey:isBold ? @"bhtwitter_font_2" : @"bhtwitter_font_1"];
+    if (!customName) {
+        return origFont;
+    }
+
+    return [UIFont fontWithName:customName size:size] ?: origFont;
 }
 %end
 

--- a/src/Hooks/Theme.x
+++ b/src/Hooks/Theme.x
@@ -35,6 +35,236 @@ void applySelectedThemeColor(void) {
     }
 }
 
+// MARK: - Dim background recolor
+
+// The app only ever renders Light or Dark now -- there's no native third
+// option -- so Dim comes back by intercepting Dark's palette at its one
+// choke point and swapping in a proxy that recolors just the background
+// family, leaving Light untouched.
+%hook TAETwitterColorPaletteSettingInfo
+
+- (id<TAEColorPalette>)colorPalette {
+    id<TAEColorPalette> realPalette = %orig;
+    if (self.isDark && BHTDimThemeEnabled()) {
+        return (id<TAEColorPalette>)[BHTDimPaletteProxy proxyWithPalette:realPalette];
+    }
+    return realPalette;
+}
+
+%end
+
+// Headers, small containers, profile pages, and the boxes around some cells
+// don't go through TAEColorPalette at all -- they're drawn with UIKit's own
+// dynamic system background colors, which Apple defines as pure black (or
+// near enough) in Dark. Re-point those at the same three Dim shades so
+// nothing native-styled is left behind.
+%hook UIColor
+
++ (UIColor*)systemBackgroundColor {
+    UIColor* original = %orig;
+    if (!BHTDimThemeEnabled()) {
+        return original;
+    }
+    return [UIColor colorWithDynamicProvider:^UIColor*(UITraitCollection* traits) {
+        return traits.userInterfaceStyle == UIUserInterfaceStyleDark ? BHTDimBackgroundColor()
+                                                                       : original;
+    }];
+}
+
++ (UIColor*)secondarySystemBackgroundColor {
+    UIColor* original = %orig;
+    if (!BHTDimThemeEnabled()) {
+        return original;
+    }
+    return [UIColor colorWithDynamicProvider:^UIColor*(UITraitCollection* traits) {
+        return traits.userInterfaceStyle == UIUserInterfaceStyleDark ? BHTDimElevatedBackgroundColor()
+                                                                       : original;
+    }];
+}
+
++ (UIColor*)tertiarySystemBackgroundColor {
+    UIColor* original = %orig;
+    if (!BHTDimThemeEnabled()) {
+        return original;
+    }
+    return [UIColor colorWithDynamicProvider:^UIColor*(UITraitCollection* traits) {
+        return traits.userInterfaceStyle == UIUserInterfaceStyleDark ? BHTDimHighlightBackgroundColor()
+                                                                       : original;
+    }];
+}
+
++ (UIColor*)systemGroupedBackgroundColor {
+    UIColor* original = %orig;
+    if (!BHTDimThemeEnabled()) {
+        return original;
+    }
+    return [UIColor colorWithDynamicProvider:^UIColor*(UITraitCollection* traits) {
+        return traits.userInterfaceStyle == UIUserInterfaceStyleDark ? BHTDimBackgroundColor()
+                                                                       : original;
+    }];
+}
+
++ (UIColor*)secondarySystemGroupedBackgroundColor {
+    UIColor* original = %orig;
+    if (!BHTDimThemeEnabled()) {
+        return original;
+    }
+    return [UIColor colorWithDynamicProvider:^UIColor*(UITraitCollection* traits) {
+        return traits.userInterfaceStyle == UIUserInterfaceStyleDark ? BHTDimElevatedBackgroundColor()
+                                                                       : original;
+    }];
+}
+
++ (UIColor*)tertiarySystemGroupedBackgroundColor {
+    UIColor* original = %orig;
+    if (!BHTDimThemeEnabled()) {
+        return original;
+    }
+    return [UIColor colorWithDynamicProvider:^UIColor*(UITraitCollection* traits) {
+        return traits.userInterfaceStyle == UIUserInterfaceStyleDark ? BHTDimHighlightBackgroundColor()
+                                                                       : original;
+    }];
+}
+
+%end
+
+// The six named colors above only cover code that calls those exact class
+// methods. Plenty of chrome (profile headers, small containers, boxes around
+// cells) instead gets its color from a UIDynamicSystemColor (system colors)
+// or UIDynamicCatalogColor (colors loaded from an asset catalog, including
+// Twitter's own named design-system colors, which we have no way to
+// enumerate) stored directly on a view's backgroundColor. Both are UIColor
+// subclasses that funnel through -resolvedColorWithTraitCollection: at draw
+// time -- hooking there catches every source at once, not just the ones we
+// know the name of.
+@interface UIDynamicSystemColor : UIColor
+@end
+@interface UIDynamicCatalogColor : UIColor
+@end
+// UIExtendedSRGBColorSpace is the concrete storage class behind essentially
+// every flat (non-dynamic) UIColor, not just background colors -- so unlike
+// the two hooks above, this one leans hard on BHTDimReplacementForResolvedColor's
+// filtering (opaque, achromatic, near-black only) to avoid ever touching flat
+// black text, icon tints, shadows, or borders that happen to share the class.
+@interface UIExtendedSRGBColorSpace : UIColor
+@end
+
+@interface UIDeviceRGBColor: UIColor
+@end
+
+%hook UIDynamicSystemColor
+
+- (UIColor*)resolvedColorWithTraitCollection:(UITraitCollection*)traitCollection {
+    UIColor* original = %orig;
+    if (BHTColorIsDimExempt(self)) {
+        return original;
+    }
+    if (!BHTDimThemeEnabled() || traitCollection.userInterfaceStyle != UIUserInterfaceStyleDark) {
+        return original;
+    }
+    UIColor* replacement = BHTDimReplacementForResolvedColor(original);
+    return replacement ?: original;
+}
+
+%end
+
+%hook UIDeviceRGBColor
+- (UIColor*)resolvedColorWithTraitCollection:(UITraitCollection*)traitCollection {
+    UIColor* original = %orig;
+    if (BHTColorIsDimExempt(self)) {
+        return original;
+    }
+    if (!BHTDimThemeEnabled() || traitCollection.userInterfaceStyle != UIUserInterfaceStyleDark) {
+        return original;
+    }
+    UIColor* replacement = BHTDimReplacementForResolvedColor(original);
+    return replacement ?: original;
+}
+
+%end
+
+%hook UIDynamicCatalogColor
+
+- (UIColor*)resolvedColorWithTraitCollection:(UITraitCollection*)traitCollection {
+    UIColor* original = %orig;
+    if (BHTColorIsDimExempt(self)) {
+        return original;
+    }
+    if (!BHTDimThemeEnabled() || traitCollection.userInterfaceStyle != UIUserInterfaceStyleDark) {
+        return original;
+    }
+    UIColor* replacement = BHTDimReplacementForResolvedColor(original);
+    return replacement ?: original;
+}
+
+%end
+
+%hook UIExtendedSRGBColorSpace
+
+- (UIColor*)resolvedColorWithTraitCollection:(UITraitCollection*)traitCollection {
+    UIColor* original = %orig;
+    if (BHTColorIsDimExempt(self)) {
+        return original;
+    }
+    if (!BHTDimThemeEnabled() || traitCollection.userInterfaceStyle != UIUserInterfaceStyleDark) {
+        return original;
+    }
+    UIColor* replacement = BHTDimReplacementForResolvedColor(original);
+    return replacement ?: original;
+}
+
+%end
+
+%hook TFNSolidColorView
+
+-(void) didMoveToWindow {
+    %orig;
+    if (BHTDimThemeEnabled()) {
+        self.hidden = TRUE;
+    }
+}
+
+%end
+
+// TFNButton blends into Dim's navy too well, so its background should stay
+// whatever Twitter itself set it to. Skipping our own explicit recolor in
+// the UIView hook below isn't enough on its own: that color is still an
+// instance of one of the four classes hooked above, which will substitute it
+// regardless of which view holds it. Marking the exact color instance here,
+// at the moment it's assigned, is what actually keeps the four hooks above
+// from touching it.
+%hook TFNButton
+
+- (void)setBackgroundColor:(UIColor*)color {
+    if (BHTColorIsCloseToWhite(color)) {
+        BHTMarkColorDimExempt(color);
+    }
+    %orig(color);
+}
+
+%end
+
+%hook UIView
+-(void) didMoveToWindow {
+    %orig;
+    if ([self isKindOfClass:objc_getClass("TFNButton")] || [self isKindOfClass:objc_getClass("UIImageView")]) {
+        return;
+    }
+    if ([self superview] && [self.superview isKindOfClass:objc_getClass("TFNSolidColorView")]) {
+        if (BHTDimThemeEnabled()) {
+            // This override is unconditional and bypasses the resolvedColor
+            // heuristic entirely, so white chrome needs its own explicit
+            // guard here -- forcing it to Dim navy would wreck readability.
+            if (BHTColorIsCloseToWhite(self.backgroundColor)) {
+                return;
+            }
+            self.backgroundColor = BHTDimBackgroundColor();
+        }
+    }
+}
+
+%end
+
 // MARK: - Custom tab bar order and visibility
 
 static NSString* scribePageForEntry(id<T1AppNavigationTabEntry> entry) {

--- a/src/Hooks/Theme.x
+++ b/src/Hooks/Theme.x
@@ -4,7 +4,7 @@
 //
 
 #import "HookHelpers.h"
-#import "UIHeaders.h"
+#import "Headers/UIHeaders.h"
 
 // MARK: - Custom accent color
 

--- a/src/Hooks/Theme.x
+++ b/src/Hooks/Theme.x
@@ -4,6 +4,7 @@
 //
 
 #import "HookHelpers.h"
+#import "UIHeaders.h"
 
 // MARK: - Custom accent color
 
@@ -128,37 +129,10 @@ void applySelectedThemeColor(void) {
 
 %end
 
-// The six named colors above only cover code that calls those exact class
-// methods. Plenty of chrome (profile headers, small containers, boxes around
-// cells) instead gets its color from a UIDynamicSystemColor (system colors)
-// or UIDynamicCatalogColor (colors loaded from an asset catalog, including
-// Twitter's own named design-system colors, which we have no way to
-// enumerate) stored directly on a view's backgroundColor. Both are UIColor
-// subclasses that funnel through -resolvedColorWithTraitCollection: at draw
-// time -- hooking there catches every source at once, not just the ones we
-// know the name of.
-@interface UIDynamicSystemColor : UIColor
-@end
-@interface UIDynamicCatalogColor : UIColor
-@end
-// UIExtendedSRGBColorSpace is the concrete storage class behind essentially
-// every flat (non-dynamic) UIColor, not just background colors -- so unlike
-// the two hooks above, this one leans hard on BHTDimReplacementForResolvedColor's
-// filtering (opaque, achromatic, near-black only) to avoid ever touching flat
-// black text, icon tints, shadows, or borders that happen to share the class.
-@interface UIExtendedSRGBColorSpace : UIColor
-@end
-
-@interface UIDeviceRGBColor: UIColor
-@end
-
 %hook UIDynamicSystemColor
 
 - (UIColor*)resolvedColorWithTraitCollection:(UITraitCollection*)traitCollection {
     UIColor* original = %orig;
-    if (BHTColorIsDimExempt(self)) {
-        return original;
-    }
     if (!BHTDimThemeEnabled() || traitCollection.userInterfaceStyle != UIUserInterfaceStyleDark) {
         return original;
     }
@@ -171,9 +145,6 @@ void applySelectedThemeColor(void) {
 %hook UIDeviceRGBColor
 - (UIColor*)resolvedColorWithTraitCollection:(UITraitCollection*)traitCollection {
     UIColor* original = %orig;
-    if (BHTColorIsDimExempt(self)) {
-        return original;
-    }
     if (!BHTDimThemeEnabled() || traitCollection.userInterfaceStyle != UIUserInterfaceStyleDark) {
         return original;
     }
@@ -187,9 +158,6 @@ void applySelectedThemeColor(void) {
 
 - (UIColor*)resolvedColorWithTraitCollection:(UITraitCollection*)traitCollection {
     UIColor* original = %orig;
-    if (BHTColorIsDimExempt(self)) {
-        return original;
-    }
     if (!BHTDimThemeEnabled() || traitCollection.userInterfaceStyle != UIUserInterfaceStyleDark) {
         return original;
     }
@@ -203,9 +171,6 @@ void applySelectedThemeColor(void) {
 
 - (UIColor*)resolvedColorWithTraitCollection:(UITraitCollection*)traitCollection {
     UIColor* original = %orig;
-    if (BHTColorIsDimExempt(self)) {
-        return original;
-    }
     if (!BHTDimThemeEnabled() || traitCollection.userInterfaceStyle != UIUserInterfaceStyleDark) {
         return original;
     }
@@ -221,45 +186,6 @@ void applySelectedThemeColor(void) {
     %orig;
     if (BHTDimThemeEnabled()) {
         self.hidden = TRUE;
-    }
-}
-
-%end
-
-// TFNButton blends into Dim's navy too well, so its background should stay
-// whatever Twitter itself set it to. Skipping our own explicit recolor in
-// the UIView hook below isn't enough on its own: that color is still an
-// instance of one of the four classes hooked above, which will substitute it
-// regardless of which view holds it. Marking the exact color instance here,
-// at the moment it's assigned, is what actually keeps the four hooks above
-// from touching it.
-%hook TFNButton
-
-- (void)setBackgroundColor:(UIColor*)color {
-    if (BHTColorIsCloseToWhite(color)) {
-        BHTMarkColorDimExempt(color);
-    }
-    %orig(color);
-}
-
-%end
-
-%hook UIView
--(void) didMoveToWindow {
-    %orig;
-    if ([self isKindOfClass:objc_getClass("TFNButton")] || [self isKindOfClass:objc_getClass("UIImageView")]) {
-        return;
-    }
-    if ([self superview] && [self.superview isKindOfClass:objc_getClass("TFNSolidColorView")]) {
-        if (BHTDimThemeEnabled()) {
-            // This override is unconditional and bypasses the resolvedColor
-            // heuristic entirely, so white chrome needs its own explicit
-            // guard here -- forcing it to Dim navy would wreck readability.
-            if (BHTColorIsCloseToWhite(self.backgroundColor)) {
-                return;
-            }
-            self.backgroundColor = BHTDimBackgroundColor();
-        }
     }
 }
 

--- a/src/Settings/Pages/AppearanceSettingsViewController.m
+++ b/src/Settings/Pages/AppearanceSettingsViewController.m
@@ -177,6 +177,23 @@
         dispatch_async(dispatch_get_main_queue(), ^{
             [self refreshAllTabViews];
         });
+    } else if ([key isEqualToString:@"enable_dim_theme"]) {
+        UIAlertController* alertController =
+            [UIAlertController alertControllerWithTitle:[[BHTBundle sharedBundle]
+                                                            localizedStringForKey:@"DIM_THEME_RESTART_ALERT_TITLE"]
+                                                    message:[[BHTBundle sharedBundle]
+                                                                localizedStringForKey:@"DIM_THEME_RESTART_ALERT_MESSAGE"]
+                                                preferredStyle:UIAlertControllerStyleAlert];
+                                                
+        alertController.modalPresentationStyle = UIModalPresentationFullScreen;
+        UIAlertAction* restartAction = [UIAlertAction actionWithTitle:[[BHTBundle sharedBundle]
+                                                    localizedStringForKey:@"DIM_THEME_RESTART_ALERT_RESTART_BUTTON"]
+                                                    style:UIAlertActionStyleDestructive
+                                                    handler:^(UIAlertAction* action) {
+                                                        exit(0);
+                                                    }];
+        [alertController addAction:restartAction];
+        [self presentViewController:alertController animated:YES completion:nil];
     }
 }
 

--- a/src/ThemeColor/BHTDimPalette.h
+++ b/src/ThemeColor/BHTDimPalette.h
@@ -46,15 +46,6 @@ UIColor* _Nullable BHTDimReplacementForResolvedColor(UIColor* resolved);
  */
 BOOL BHTColorIsCloseToWhite(UIColor* _Nullable color);
 
-/**
- * -resolvedColorWithTraitCollection: hooks have no notion of which view is
- * asking -- they only ever see the color instance. To exempt a specific
- * view's color from those hooks, mark the exact UIColor instance it's
- * assigned as exempt (e.g. from that view's -setBackgroundColor: override)
- * and have the resolution hooks check it before substituting.
- */
-void BHTMarkColorDimExempt(UIColor* _Nullable color);
-BOOL BHTColorIsDimExempt(UIColor* _Nullable color);
 
 /**
  * Wraps a live TAEColorPalette-conforming object, substituting Dim's navy

--- a/src/ThemeColor/BHTDimPalette.h
+++ b/src/ThemeColor/BHTDimPalette.h
@@ -1,0 +1,73 @@
+//
+//  BHTDimPalette.h
+//  NeoFreeBird
+//
+//  Created by orionblur
+//
+
+#import <UIKit/UIKit.h>
+
+/**
+ * Whether the classic Twitter "Dim" recolor should replace the app's native
+ * Dark palette. Hardcoded on for now; swap the body for a BHTSettings lookup
+ * once there's a settings entry for it.
+ */
+BOOL BHTDimThemeEnabled(void);
+
+/**
+ * The three Dim shades, for direct use where a caller isn't going through the
+ * palette proxy below (e.g. overriding UIKit's own dynamic system colors,
+ * which are a separate source of "pure black" chrome the TAEColorPalette
+ * proxy never sees).
+ */
+UIColor* BHTDimBackgroundColor(void);
+UIColor* BHTDimElevatedBackgroundColor(void);
+UIColor* BHTDimHighlightBackgroundColor(void);
+
+/**
+ * Best-effort remap for a color that's already been resolved for a trait
+ * collection (i.e. flattened to concrete RGBA), used to catch UIKit's
+ * private dynamic-color classes (UIDynamicSystemColor, UIDynamicCatalogColor)
+ * which never go through TAEColorPalette or the named UIColor class methods.
+ * Only touches colors that look like opaque, achromatic background chrome
+ * (near-black grays); returns nil -- meaning "leave it alone" -- for
+ * anything with real hue, transparency, or brightness outside that band, so
+ * text, accents, and translucent overlays are never touched.
+ */
+UIColor* _Nullable BHTDimReplacementForResolvedColor(UIColor* resolved);
+
+/**
+ * Self-contained "is this white/near-white" check, used to keep genuinely
+ * white chrome from being force-overwritten by the blanket TFNSolidColorView
+ * recolor in Theme.x (that override doesn't go through
+ * BHTDimReplacementForResolvedColor's heuristic at all, so it needs its own
+ * guard). Deliberately not relying on UIColor's private safari_isCloseToWhite
+ * category -- undocumented, and it didn't produce reliable results here.
+ */
+BOOL BHTColorIsCloseToWhite(UIColor* _Nullable color);
+
+/**
+ * -resolvedColorWithTraitCollection: hooks have no notion of which view is
+ * asking -- they only ever see the color instance. To exempt a specific
+ * view's color from those hooks, mark the exact UIColor instance it's
+ * assigned as exempt (e.g. from that view's -setBackgroundColor: override)
+ * and have the resolution hooks check it before substituting.
+ */
+void BHTMarkColorDimExempt(UIColor* _Nullable color);
+BOOL BHTColorIsDimExempt(UIColor* _Nullable color);
+
+/**
+ * Wraps a live TAEColorPalette-conforming object, substituting Dim's navy
+ * background family for the handful of properties it overrides and
+ * forwarding everything else (text, links, accents, dividers) untouched to
+ * the wrapped palette.
+ *
+ * The app only ever renders Light or Dark now -- there's no native third
+ * state -- so this is how Dim comes back: it recolors Dark rather than
+ * adding an option alongside it.
+ */
+@interface BHTDimPaletteProxy : NSProxy
+
++ (instancetype)proxyWithPalette:(id)palette;
+
+@end

--- a/src/ThemeColor/BHTDimPalette.m
+++ b/src/ThemeColor/BHTDimPalette.m
@@ -99,27 +99,6 @@ BOOL BHTColorIsCloseToWhite(UIColor* color) {
     return minComponent > 0.9;
 }
 
-// The resolvedColorWithTraitCollection: hooks only ever see a color instance,
-// never the view it's attached to, so a view-level exemption (e.g. skipping
-// TFNButton in a didMoveToWindow hook) can't stop those hooks from still
-// recoloring whatever the view's own backgroundColor already was. Marking
-// the exact color instance here, from the view's -setBackgroundColor:
-// override, gives both layers a shared signal to check.
-static const void* kBHTDimExemptColorKey = &kBHTDimExemptColorKey;
-
-void BHTMarkColorDimExempt(UIColor* color) {
-    if (!color) {
-        return;
-    }
-    objc_setAssociatedObject(color, kBHTDimExemptColorKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-}
-
-BOOL BHTColorIsDimExempt(UIColor* color) {
-    if (!color) {
-        return NO;
-    }
-    return [objc_getAssociatedObject(color, kBHTDimExemptColorKey) boolValue];
-}
 
 @interface BHTDimPaletteProxy ()
 @property (nonatomic, strong) id realPalette;
@@ -182,72 +161,94 @@ BOOL BHTColorIsDimExempt(UIColor* color) {
 #pragma mark - Overridden background family
 
 - (UIColor*)backgroundColor {
-    return BHTDimBackgroundColor();
+    UIColor* real = [self.realPalette backgroundColor];
+    return BHTColorIsCloseToWhite(real) ? real : BHTDimBackgroundColor();
 }
-- (UIColor*) backgroundPrimary {
-    return BHTDimBackgroundColor();
+- (UIColor*)backgroundPrimary {
+    UIColor* real = [self.realPalette backgroundPrimary];
+    return BHTColorIsCloseToWhite(real) ? real : BHTDimBackgroundColor();
 }
 - (UIColor*)darkBackgroundColor {
-    return BHTDimBackgroundColor();
+    UIColor* real = [self.realPalette darkBackgroundColor];
+    return BHTColorIsCloseToWhite(real) ? real : BHTDimBackgroundColor();
 }
 - (UIColor*)cardHeaderBackgroundColor {
-    return BHTDimBackgroundColor();
+    UIColor* real = [self.realPalette cardHeaderBackgroundColor];
+    return BHTColorIsCloseToWhite(real) ? real : BHTDimBackgroundColor();
 }
 - (UIColor*)modalSheetBackgroundColor {
-    return BHTDimBackgroundColor();
+    UIColor* real = [self.realPalette modalSheetBackgroundColor];
+    return BHTColorIsCloseToWhite(real) ? real : BHTDimBackgroundColor();
 }
 - (UIColor*)messagingBackgroundColor {
-    return BHTDimBackgroundColor();
+    UIColor* real = [self.realPalette messagingBackgroundColor];
+    return BHTColorIsCloseToWhite(real) ? real : BHTDimBackgroundColor();
 }
 
 - (UIColor*)secondaryBackgroundColor {
-    return BHTDimElevatedBackgroundColor();
+    UIColor* real = [self.realPalette secondaryBackgroundColor];
+    return BHTColorIsCloseToWhite(real) ? real : BHTDimElevatedBackgroundColor();
 }
 - (UIColor*)faintBackgroundColor {
-    return BHTDimElevatedBackgroundColor();
+    UIColor* real = [self.realPalette faintBackgroundColor];
+    return BHTColorIsCloseToWhite(real) ? real : BHTDimElevatedBackgroundColor();
 }
 - (UIColor*)itemDarkBackgroundColor {
-    return BHTDimElevatedBackgroundColor();
+    UIColor* real = [self.realPalette itemDarkBackgroundColor];
+    return BHTColorIsCloseToWhite(real) ? real : BHTDimElevatedBackgroundColor();
 }
 - (UIColor*)elevatedBackgroundColor {
-    return BHTDimElevatedBackgroundColor();
+    UIColor* real = [self.realPalette elevatedBackgroundColor];
+    return BHTColorIsCloseToWhite(real) ? real : BHTDimElevatedBackgroundColor();
 }
 - (UIColor*)toastsBackgroundColor {
-    return BHTDimElevatedBackgroundColor();
+    UIColor* real = [self.realPalette toastsBackgroundColor];
+    return BHTColorIsCloseToWhite(real) ? real : BHTDimElevatedBackgroundColor();
 }
 - (UIColor*)tileBackgroundColor {
-    return BHTDimElevatedBackgroundColor();
+    UIColor* real = [self.realPalette tileBackgroundColor];
+    return BHTColorIsCloseToWhite(real) ? real : BHTDimElevatedBackgroundColor();
 }
 - (UIColor*)cardDetailsBackgroundColor {
-    return BHTDimElevatedBackgroundColor();
+    UIColor* real = [self.realPalette cardDetailsBackgroundColor];
+    return BHTColorIsCloseToWhite(real) ? real : BHTDimElevatedBackgroundColor();
 }
 - (UIColor*)premiumTiersCardBackgroundColor {
-    return BHTDimElevatedBackgroundColor();
+    UIColor* real = [self.realPalette premiumTiersCardBackgroundColor];
+    return BHTColorIsCloseToWhite(real) ? real : BHTDimElevatedBackgroundColor();
 }
 - (UIColor*)tweetConversationAdBackgroundColor {
-    return BHTDimElevatedBackgroundColor();
+    UIColor* real = [self.realPalette tweetConversationAdBackgroundColor];
+    return BHTColorIsCloseToWhite(real) ? real : BHTDimElevatedBackgroundColor();
 }
 - (UIColor*)chatTopicBackgroundColor {
-    return BHTDimElevatedBackgroundColor();
+    UIColor* real = [self.realPalette chatTopicBackgroundColor];
+    return BHTColorIsCloseToWhite(real) ? real : BHTDimElevatedBackgroundColor();
 }
 - (UIColor*)dmBubbleIncomingColor {
-    return BHTDimElevatedBackgroundColor();
+    UIColor* real = [self.realPalette dmBubbleIncomingColor];
+    return BHTColorIsCloseToWhite(real) ? real : BHTDimElevatedBackgroundColor();
 }
 
 - (UIColor*)highlightBackgroundColor {
-    return BHTDimHighlightBackgroundColor();
+    UIColor* real = [self.realPalette highlightBackgroundColor];
+    return BHTColorIsCloseToWhite(real) ? real : BHTDimHighlightBackgroundColor();
 }
 - (UIColor*)unreadBackgroundColor {
-    return BHTDimHighlightBackgroundColor();
+    UIColor* real = [self.realPalette unreadBackgroundColor];
+    return BHTColorIsCloseToWhite(real) ? real : BHTDimHighlightBackgroundColor();
 }
 - (UIColor*)highlightedStatusBackgroundColor {
-    return BHTDimHighlightBackgroundColor();
+    UIColor* real = [self.realPalette highlightedStatusBackgroundColor];
+    return BHTColorIsCloseToWhite(real) ? real : BHTDimHighlightBackgroundColor();
 }
 - (UIColor*)statusCellOverlayColor {
-    return BHTDimHighlightBackgroundColor();
+    UIColor* real = [self.realPalette statusCellOverlayColor];
+    return BHTColorIsCloseToWhite(real) ? real : BHTDimHighlightBackgroundColor();
 }
 - (UIColor*)dmInboxCellSelectionBackgroundColor {
-    return BHTDimHighlightBackgroundColor();
+    UIColor* real = [self.realPalette dmInboxCellSelectionBackgroundColor];
+    return BHTColorIsCloseToWhite(real) ? real : BHTDimHighlightBackgroundColor();
 }
 
 @end

--- a/src/ThemeColor/BHTDimPalette.m
+++ b/src/ThemeColor/BHTDimPalette.m
@@ -1,0 +1,256 @@
+//
+//  BHTDimPalette.m
+//  NeoFreeBird
+//
+//  Created by orionblur
+//
+
+#import "ThemeColor/BHTDimPalette.h"
+#import <objc/runtime.h>
+
+BOOL BHTDimThemeEnabled(void) {
+    return YES;
+}
+
+static UIColor* BHTColorWithRGB(uint32_t rgb) {
+    return [UIColor colorWithRed:((rgb >> 16) & 0xFF) / 255.0
+                            green:((rgb >> 8) & 0xFF) / 255.0
+                             blue:(rgb & 0xFF) / 255.0
+                            alpha:1.0];
+}
+
+// Classic Twitter Dim palette: a navy background, a slightly lighter navy for
+// anything elevated/secondary, and a lighter shade still for pressed/selected
+// states. Text, links, and accent colors are left alone -- Dim only ever
+// changed the background family, never the foreground. Exposed (not static)
+// so Theme.x's UIColor hook can reuse the same three shades.
+UIColor* BHTDimBackgroundColor(void) {
+    return BHTColorWithRGB(0x15202B);
+}
+UIColor* BHTDimElevatedBackgroundColor(void) {
+    return BHTColorWithRGB(0x192734);
+}
+UIColor* BHTDimHighlightBackgroundColor(void) {
+    return BHTColorWithRGB(0x1C2836);
+}
+
+// UIDynamicSystemColor/UIDynamicCatalogColor (the private classes backing
+// UIKit's system colors and asset-catalog +colorNamed: colors) never go
+// through TAEColorPalette or the named UIColor class methods, so anything
+// they draw has to be caught after the fact, once resolved to a flat RGBA
+// color. Since we don't know which named color it was, only remap colors
+// that plausibly *are* background chrome: fully opaque and achromatic (no
+// real hue -- rules out accent colors, media, everything colorful), sitting
+// in the narrow near-black band Apple actually uses for dark background
+// tones (systemBackground ~0.0, secondarySystemBackground ~0.11,
+// tertiarySystemBackground ~0.17). Brighter grays are left untouched, since
+// those are far more likely to be label/fill/separator colors that need to
+// stay legible rather than become part of the background.
+UIColor* _Nullable BHTDimReplacementForResolvedColor(UIColor* resolved) {
+    CGFloat red = 0, green = 0, blue = 0, alpha = 0;
+    if (![resolved getRed:&red green:&green blue:&blue alpha:&alpha]) {
+        return nil;
+    }
+    if (alpha < 0.99) {
+        return nil;
+    }
+
+    CGFloat maxComponent = MAX(red, MAX(green, blue));
+    CGFloat minComponent = MIN(red, MIN(green, blue));
+    if (maxComponent - minComponent > 0.04) {
+        return nil;
+    }
+    if (maxComponent > 0.22) {
+        return nil;
+    }
+
+    if (maxComponent < 0.05) {
+        return BHTDimBackgroundColor();
+    }
+    if (maxComponent < 0.14) {
+        return BHTDimElevatedBackgroundColor();
+    }
+    return BHTDimHighlightBackgroundColor();
+}
+
+// Self-contained white check -- deliberately not UIColor's private
+// safari_isCloseToWhite category, which didn't behave reliably here. Grayscale
+// colors (e.g. +whiteColor, which resolves via -getWhite:alpha: rather than
+// -getRed:green:blue:alpha:) are handled explicitly rather than falling
+// through to "not white".
+BOOL BHTColorIsCloseToWhite(UIColor* color) {
+    if (!color) {
+        return NO;
+    }
+
+    CGFloat red = 0, green = 0, blue = 0, alpha = 0;
+    if (![color getRed:&red green:&green blue:&blue alpha:&alpha]) {
+        CGFloat white = 0;
+        if (![color getWhite:&white alpha:&alpha]) {
+            return NO;
+        }
+        red = green = blue = white;
+    }
+    if (alpha < 0.99) {
+        return NO;
+    }
+
+    CGFloat minComponent = MIN(red, MIN(green, blue));
+    return minComponent > 0.9;
+}
+
+// The resolvedColorWithTraitCollection: hooks only ever see a color instance,
+// never the view it's attached to, so a view-level exemption (e.g. skipping
+// TFNButton in a didMoveToWindow hook) can't stop those hooks from still
+// recoloring whatever the view's own backgroundColor already was. Marking
+// the exact color instance here, from the view's -setBackgroundColor:
+// override, gives both layers a shared signal to check.
+static const void* kBHTDimExemptColorKey = &kBHTDimExemptColorKey;
+
+void BHTMarkColorDimExempt(UIColor* color) {
+    if (!color) {
+        return;
+    }
+    objc_setAssociatedObject(color, kBHTDimExemptColorKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+BOOL BHTColorIsDimExempt(UIColor* color) {
+    if (!color) {
+        return NO;
+    }
+    return [objc_getAssociatedObject(color, kBHTDimExemptColorKey) boolValue];
+}
+
+@interface BHTDimPaletteProxy ()
+@property (nonatomic, strong) id realPalette;
+@end
+
+@implementation BHTDimPaletteProxy
+
++ (instancetype)proxyWithPalette:(id)palette {
+    BHTDimPaletteProxy* proxy = [BHTDimPaletteProxy alloc];
+    proxy.realPalette = palette;
+    return proxy;
+}
+
+#pragma mark - Forwarding
+
+// Anything we don't explicitly override below (text, links, accents,
+// dividers, primaryColorForOption:, ...) goes straight through to the real
+// palette untouched via this fast path.
+- (id)forwardingTargetForSelector:(SEL)selector {
+    return self.realPalette;
+}
+
+// NSProxy's -respondsToSelector:/-conformsToProtocol:/-isKindOfClass: are not
+// implemented in terms of -forwardingTargetForSelector: -- they're "real"
+// methods on NSProxy itself, so they never reach our overrides above and
+// instead fall into the slow invocation-based forwarding path below. Swift's
+// dynamic protocol casts (`as? TAEColorPalette`) call -conformsToProtocol:
+// directly, so without an explicit override here the proxy answers NO/crashes
+// instead of transparently reporting whatever the real palette would.
+- (BOOL)respondsToSelector:(SEL)selector {
+    return [super respondsToSelector:selector] || [self.realPalette respondsToSelector:selector];
+}
+
+- (BOOL)conformsToProtocol:(Protocol*)protocol {
+    return [self.realPalette conformsToProtocol:protocol];
+}
+
+- (BOOL)isKindOfClass:(Class)aClass {
+    return [self.realPalette isKindOfClass:aClass];
+}
+
+- (BOOL)isMemberOfClass:(Class)aClass {
+    return [self.realPalette isMemberOfClass:aClass];
+}
+
+- (Class)class {
+    return [self.realPalette class];
+}
+
+// Slow-path forwarding: a safety net for anything the fast path above
+// doesn't catch (e.g. selectors NSProxy itself implements).
+- (NSMethodSignature*)methodSignatureForSelector:(SEL)selector {
+    return [self.realPalette methodSignatureForSelector:selector];
+}
+
+- (void)forwardInvocation:(NSInvocation*)invocation {
+    [invocation invokeWithTarget:self.realPalette];
+}
+
+#pragma mark - Overridden background family
+
+- (UIColor*)backgroundColor {
+    return BHTDimBackgroundColor();
+}
+- (UIColor*) backgroundPrimary {
+    return BHTDimBackgroundColor();
+}
+- (UIColor*)darkBackgroundColor {
+    return BHTDimBackgroundColor();
+}
+- (UIColor*)cardHeaderBackgroundColor {
+    return BHTDimBackgroundColor();
+}
+- (UIColor*)modalSheetBackgroundColor {
+    return BHTDimBackgroundColor();
+}
+- (UIColor*)messagingBackgroundColor {
+    return BHTDimBackgroundColor();
+}
+
+- (UIColor*)secondaryBackgroundColor {
+    return BHTDimElevatedBackgroundColor();
+}
+- (UIColor*)faintBackgroundColor {
+    return BHTDimElevatedBackgroundColor();
+}
+- (UIColor*)itemDarkBackgroundColor {
+    return BHTDimElevatedBackgroundColor();
+}
+- (UIColor*)elevatedBackgroundColor {
+    return BHTDimElevatedBackgroundColor();
+}
+- (UIColor*)toastsBackgroundColor {
+    return BHTDimElevatedBackgroundColor();
+}
+- (UIColor*)tileBackgroundColor {
+    return BHTDimElevatedBackgroundColor();
+}
+- (UIColor*)cardDetailsBackgroundColor {
+    return BHTDimElevatedBackgroundColor();
+}
+- (UIColor*)premiumTiersCardBackgroundColor {
+    return BHTDimElevatedBackgroundColor();
+}
+- (UIColor*)tweetConversationAdBackgroundColor {
+    return BHTDimElevatedBackgroundColor();
+}
+- (UIColor*)chatTopicBackgroundColor {
+    return BHTDimElevatedBackgroundColor();
+}
+- (UIColor*)dmBubbleIncomingColor {
+    return BHTDimElevatedBackgroundColor();
+}
+
+- (UIColor*)highlightBackgroundColor {
+    return BHTDimHighlightBackgroundColor();
+}
+- (UIColor*)unreadBackgroundColor {
+    return BHTDimHighlightBackgroundColor();
+}
+- (UIColor*)highlightedStatusBackgroundColor {
+    return BHTDimHighlightBackgroundColor();
+}
+- (UIColor*)statusCellOverlayColor {
+    return BHTDimHighlightBackgroundColor();
+}
+- (UIColor*)dmInboxCellSelectionBackgroundColor {
+    return BHTDimHighlightBackgroundColor();
+}
+
+@end
+
+
+

--- a/src/ThemeColor/BHTDimPalette.m
+++ b/src/ThemeColor/BHTDimPalette.m
@@ -6,10 +6,11 @@
 //
 
 #import "ThemeColor/BHTDimPalette.h"
+#import "Core/BHTSettings.h"
 #import <objc/runtime.h>
 
 BOOL BHTDimThemeEnabled(void) {
-    return YES;
+    return [BHTSettings boolForKey:@"enable_dim_theme"];
 }
 
 static UIColor* BHTColorWithRGB(uint32_t rgb) {


### PR DESCRIPTION
Reimplemented the dim theme into Twitter, right now it overrides the Dark theme since the app is hardcoded to only support 2 themes. 

Known issues:

- [x] No option to turn it on and off (will add)
- [x] Follow button on profile page (when scrolling) and some buttons are incorrectly themed
- [ ] Glitches when switching between light and dark mode (I don't think I can fix this, but can be fixed by restarting the app)

<img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/2d4924b1-cffd-43f8-b7dc-7b4097b6769d" />
