### PR TITLE
Fix Dim theme search and selected-tab colors

### DIFF
--- a/src/Headers/TAEHeaders.h
+++ b/src/Headers/TAEHeaders.h
@@ -23,7 +23,6 @@
 @protocol TAEColorPalette
 - (id)colorPalette;
 - (UIColor*)primaryColorForOption:(NSUInteger)colorOption;
-- (UIColor*)pillDefaultBackgroundColor;
 - (UIColor*)tabBarItemColor;
 @end
 

--- a/src/Headers/TAEHeaders.h
+++ b/src/Headers/TAEHeaders.h
@@ -23,6 +23,8 @@
 @protocol TAEColorPalette
 - (id)colorPalette;
 - (UIColor*)primaryColorForOption:(NSUInteger)colorOption;
+- (UIColor*)pillDefaultBackgroundColor;
+- (UIColor*)tabBarItemColor;
 @end
 
 @interface TAETwitterColorPaletteSettingInfo : NSObject

--- a/src/Hooks/Theme.x
+++ b/src/Hooks/Theme.x
@@ -191,6 +191,89 @@ void applySelectedThemeColor(void) {
 
 %end
 
+// X 12.9's Explore search pill is a background image owned by UISearchBar's
+// private _UITextFieldImageBackgroundView. It never asks TAEColorPalette for
+// pillDefaultBackgroundColor, so recolor it through UISearchBar's public image
+// API and preserve the native pill geometry with stretchable round caps.
+static UIImage* BHTDimSearchPillImage(void) {
+    static UIImage* image;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        const CGFloat diameter = 44.0;
+        UIGraphicsImageRenderer* renderer =
+            [[UIGraphicsImageRenderer alloc] initWithSize:CGSizeMake(diameter, diameter)];
+        UIImage* base = [renderer imageWithActions:^(UIGraphicsImageRendererContext* context) {
+            [BHTDimSearchPillColor() setFill];
+            [[UIBezierPath bezierPathWithRoundedRect:CGRectMake(0, 0, diameter, diameter)
+                                        cornerRadius:diameter / 2.0] fill];
+        }];
+        image = [base resizableImageWithCapInsets:UIEdgeInsetsMake(diameter / 2.0,
+                                                                   diameter / 2.0,
+                                                                   diameter / 2.0,
+                                                                   diameter / 2.0)
+                                         resizingMode:UIImageResizingModeStretch];
+    });
+    return image;
+}
+
+static void BHTApplyDimSearchPill(UISearchBar* searchBar) {
+    if (!BHTDimThemeEnabled() ||
+        searchBar.traitCollection.userInterfaceStyle != UIUserInterfaceStyleDark) {
+        return;
+    }
+    [searchBar setSearchFieldBackgroundImage:BHTDimSearchPillImage()
+                                    forState:UIControlStateNormal];
+}
+
+%hook TFNSearchBar
+
+- (void)layoutSubviews {
+    %orig;
+    BHTApplyDimSearchPill((UISearchBar*)self);
+}
+
+- (void)didMoveToWindow {
+    %orig;
+    BHTApplyDimSearchPill((UISearchBar*)self);
+}
+
+%end
+
+static BOOL BHTIsExploreSearchBackgroundView(UIView* view) {
+    Class searchBarClass = objc_getClass("TFNSearchBar");
+    for (UIView* ancestor = view.superview; ancestor; ancestor = ancestor.superview) {
+        if (searchBarClass && [ancestor isKindOfClass:searchBarClass]) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
+// TFNSearchBar reapplies its stock image after -layoutSubviews, so the public
+// setter above alone does not survive X's final configuration pass. Intercept
+// the concrete UIKit image owner, but only when it belongs to TFNSearchBar.
+%hook _UITextFieldImageBackgroundView
+
+- (void)setImage:(UIImage*)image {
+    if (BHTDimThemeEnabled() && BHTIsExploreSearchBackgroundView((UIView*)self) &&
+        ((UIView*)self).traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark) {
+        %orig(BHTDimSearchPillImage());
+    } else {
+        %orig(image);
+    }
+}
+
+- (void)didMoveToWindow {
+    %orig;
+    if (((UIView*)self).window && BHTDimThemeEnabled() &&
+        BHTIsExploreSearchBackgroundView((UIView*)self) &&
+        ((UIView*)self).traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark) {
+        ((UIImageView*)self).image = BHTDimSearchPillImage();
+    }
+}
+
+%end
+
 // MARK: - Custom tab bar order and visibility
 
 static NSString* scribePageForEntry(id<T1AppNavigationTabEntry> entry) {

--- a/src/ThemeColor/BHTDimPalette.h
+++ b/src/ThemeColor/BHTDimPalette.h
@@ -23,6 +23,7 @@ BOOL BHTDimThemeEnabled(void);
 UIColor* BHTDimBackgroundColor(void);
 UIColor* BHTDimElevatedBackgroundColor(void);
 UIColor* BHTDimHighlightBackgroundColor(void);
+UIColor* BHTDimSearchPillColor(void);
 
 /**
  * Best-effort remap for a color that's already been resolved for a trait

--- a/src/ThemeColor/BHTDimPalette.m
+++ b/src/ThemeColor/BHTDimPalette.m
@@ -38,7 +38,7 @@ UIColor* BHTDimHighlightBackgroundColor(void) {
 
 // The legacy Dim search field used its own neutral shade rather than any of
 // the three general-purpose background colors above.
-static UIColor* BHTDimPillBackgroundColor(void) {
+UIColor* BHTDimSearchPillColor(void) {
     return BHTColorWithRGB(0x29333F);
 }
 
@@ -249,11 +249,6 @@ BOOL BHTColorIsCloseToWhite(UIColor* color) {
     UIColor* real = [self.realPalette dmBubbleIncomingColor];
     return BHTColorIsCloseToWhite(real) ? real : BHTDimElevatedBackgroundColor();
 }
-- (UIColor*)pillDefaultBackgroundColor {
-    UIColor* real = [self.realPalette pillDefaultBackgroundColor];
-    return BHTColorIsCloseToWhite(real) ? real : BHTDimPillBackgroundColor();
-}
-
 // Twitter's current Dark palette makes the selected capsule/tab indicator
 // white. Classic Dim used the account's selected accent color instead.
 - (UIColor*)tabBarItemColor {

--- a/src/ThemeColor/BHTDimPalette.m
+++ b/src/ThemeColor/BHTDimPalette.m
@@ -6,8 +6,9 @@
 //
 
 #import "ThemeColor/BHTDimPalette.h"
-#import "Core/BHTSettings.h"
 #import <objc/runtime.h>
+#import "Core/BHTSettings.h"
+#import "Headers/TAEHeaders.h"
 
 BOOL BHTDimThemeEnabled(void) {
     return [BHTSettings boolForKey:@"enable_dim_theme"];
@@ -15,9 +16,9 @@ BOOL BHTDimThemeEnabled(void) {
 
 static UIColor* BHTColorWithRGB(uint32_t rgb) {
     return [UIColor colorWithRed:((rgb >> 16) & 0xFF) / 255.0
-                            green:((rgb >> 8) & 0xFF) / 255.0
-                             blue:(rgb & 0xFF) / 255.0
-                            alpha:1.0];
+                           green:((rgb >> 8) & 0xFF) / 255.0
+                            blue:(rgb & 0xFF) / 255.0
+                           alpha:1.0];
 }
 
 // Classic Twitter Dim palette: a navy background, a slightly lighter navy for
@@ -33,6 +34,25 @@ UIColor* BHTDimElevatedBackgroundColor(void) {
 }
 UIColor* BHTDimHighlightBackgroundColor(void) {
     return BHTColorWithRGB(0x1C2836);
+}
+
+// The legacy Dim search field used its own neutral shade rather than any of
+// the three general-purpose background colors above.
+static UIColor* BHTDimPillBackgroundColor(void) {
+    return BHTColorWithRGB(0x29333F);
+}
+
+static UIColor* BHTCurrentAccentColor(id<TAEColorPalette> palette) {
+    NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
+    NSInteger option = 0; // Twitter's default blue option.
+
+    if ([defaults objectForKey:@"bh_color_theme_selectedColor"]) {
+        option = [defaults integerForKey:@"bh_color_theme_selectedColor"];
+    } else if ([defaults objectForKey:@"T1ColorSettingsPrimaryColorOptionKey"]) {
+        option = [defaults integerForKey:@"T1ColorSettingsPrimaryColorOptionKey"];
+    }
+
+    return [palette primaryColorForOption:option] ?: [UIColor systemBlueColor];
 }
 
 // UIDynamicSystemColor/UIDynamicCatalogColor (the private classes backing
@@ -99,7 +119,6 @@ BOOL BHTColorIsCloseToWhite(UIColor* color) {
     CGFloat minComponent = MIN(red, MIN(green, blue));
     return minComponent > 0.9;
 }
-
 
 @interface BHTDimPaletteProxy ()
 @property (nonatomic, strong) id realPalette;
@@ -230,6 +249,17 @@ BOOL BHTColorIsCloseToWhite(UIColor* color) {
     UIColor* real = [self.realPalette dmBubbleIncomingColor];
     return BHTColorIsCloseToWhite(real) ? real : BHTDimElevatedBackgroundColor();
 }
+- (UIColor*)pillDefaultBackgroundColor {
+    UIColor* real = [self.realPalette pillDefaultBackgroundColor];
+    return BHTColorIsCloseToWhite(real) ? real : BHTDimPillBackgroundColor();
+}
+
+// Twitter's current Dark palette makes the selected capsule/tab indicator
+// white. Classic Dim used the account's selected accent color instead.
+- (UIColor*)tabBarItemColor {
+    UIColor* real = [self.realPalette tabBarItemColor];
+    return BHTColorIsCloseToWhite(real) ? BHTCurrentAccentColor(self.realPalette) : real;
+}
 
 - (UIColor*)highlightBackgroundColor {
     UIColor* real = [self.realPalette highlightBackgroundColor];
@@ -253,6 +283,3 @@ BOOL BHTColorIsCloseToWhite(UIColor* color) {
 }
 
 @end
-
-
-


### PR DESCRIPTION
## Summary

- restore the classic Dim search capsule color at the view that actually renders it in X 12.9
- reapply the stretchable `#29333F` pill image after X overwrites the public search-bar background during final layout
- scope the rendering hook to `_UITextFieldImageBackgroundView` instances inside `TFNSearchBar`, with Dim enabled and dark interface style
- use the configured accent for selected tab indicators in Dim mode

Fixes #27

## Validation

- built the full sideloaded app successfully with `THEOS=... make SIDELOADED=1`
- installed and tested on a physical iPhone 15 Pro running iOS 26.6 with X 12.9 / NeoFreeBird 6.4.0
- opened the live Explore search view and captured the settled rendered `TFNSearchBar` hierarchy
- verified the pill center and edge-interior pixels are exactly RGB `(41, 51, 63)` / `#29333F`
- removed all temporary device-test instrumentation before the final build and commit
- `git diff --check`