### PR TITLE
Fix Dim theme backgrounds after view reuse

### DIFF
--- a/src/Hooks/Theme.x
+++ b/src/Hooks/Theme.x
@@ -5,6 +5,7 @@
 
 #import "HookHelpers.h"
 #import "Headers/UIHeaders.h"
+#import <math.h>
 
 // MARK: - Custom accent color
 
@@ -176,6 +177,63 @@ void applySelectedThemeColor(void) {
     }
     UIColor* replacement = BHTDimReplacementForResolvedColor(original);
     return replacement ?: original;
+}
+
+%end
+
+// X 12.9 sometimes assigns backgroundPrimary (or a literal black color) to a
+// view after the palette has already been resolved. Reused timeline rows and
+// conversation/detail surfaces take this path while scrolling, so the palette
+// proxy and private UIColor resolution hooks above never get another chance to
+// recolor them. Normalize only UIView background assignments, and repeat the
+// normalization when a view enters a window so colors assigned before traits
+// were available are covered as well.
+static UIColor* BHTDimNormalizedViewBackground(UIView* view, UIColor* color) {
+    if (!view || !color || !BHTDimThemeEnabled() ||
+        view.traitCollection.userInterfaceStyle != UIUserInterfaceStyleDark) {
+        return color;
+    }
+
+    UIColor* resolved = [color resolvedColorWithTraitCollection:view.traitCollection];
+    UIColor* replacement = BHTDimReplacementForResolvedColor(resolved);
+    if (replacement) {
+        return replacement;
+    }
+
+    // The UIColor hooks may already have resolved a catalog background to a
+    // Dim shade. Pin that resolved value on the view so later reuse cannot
+    // fall back to the catalog's original pure-black dark variant.
+    CGFloat red = 0, green = 0, blue = 0, alpha = 0;
+    if ([resolved getRed:&red green:&green blue:&blue alpha:&alpha] && alpha >= 0.99) {
+        BOOL isDimShade =
+            (fabs(red - 21.0 / 255.0) < 0.002 && fabs(green - 32.0 / 255.0) < 0.002 &&
+             fabs(blue - 43.0 / 255.0) < 0.002) ||
+            (fabs(red - 25.0 / 255.0) < 0.002 && fabs(green - 39.0 / 255.0) < 0.002 &&
+             fabs(blue - 52.0 / 255.0) < 0.002) ||
+            (fabs(red - 28.0 / 255.0) < 0.002 && fabs(green - 40.0 / 255.0) < 0.002 &&
+             fabs(blue - 54.0 / 255.0) < 0.002);
+        if (isDimShade) {
+            return resolved;
+        }
+    }
+
+    return color;
+}
+
+%hook UIView
+
+- (void)setBackgroundColor:(UIColor*)color {
+    %orig(BHTDimNormalizedViewBackground(self, color));
+}
+
+- (void)didMoveToWindow {
+    %orig;
+    if (self.window && self.backgroundColor) {
+        UIColor* normalized = BHTDimNormalizedViewBackground(self, self.backgroundColor);
+        if (normalized != self.backgroundColor) {
+            self.backgroundColor = normalized;
+        }
+    }
 }
 
 %end

--- a/src/ThemeColor/BHTDimPalette.m
+++ b/src/ThemeColor/BHTDimPalette.m
@@ -255,4 +255,3 @@ BOOL BHTColorIsCloseToWhite(UIColor* color) {
 @end
 
 
-


### PR DESCRIPTION
## Problem

X 12.9 can bypass the Dim palette after initial rendering. During timeline reuse, scrolling, conversation rendering, and tweet-detail navigation it assigns `backgroundPrimary` or a literal near-black color directly to a `UIView`. Those late assignments never pass through `BHTDimPaletteProxy`, and views created before their dark traits are attached can also miss the existing private `UIColor` resolution hooks. The result is the pure-black quoted-post cards, top bar, and tweet-detail surfaces shown in issue #29.

## Fix

- normalize background colors at the `UIView` assignment boundary while Dim is enabled and the view is in dark interface style
- reuse the existing conservative Dim background classifier, so transparent colors, foregrounds, accent colors, and brighter fills remain untouched
- repeat normalization when a view enters a window, covering views configured before a usable trait collection existed
- pin already-resolved `#15202B`, `#192734`, and `#1C2836` values so reused views cannot fall back to the source catalog color
- leave Light mode and ordinary Dark mode unchanged

## Why this boundary

Adding more guessed palette selectors would not cover X 12.9s late direct assignments. The live hierarchy shows affected roots still carrying the `backgroundPrimary` catalog color even after initial palette resolution. Normalizing the view background is the narrow common boundary shared by the reported header, quoted-content, conversation, and detail surfaces.

## Validation

- reproduced the black fallback after relaunch/view reuse in X 12.9 / NeoFreeBird 6.4.0
- instrumented and inspected the live rendered hierarchy on a physical iPhone 15 Pro running iOS 26.6
- verified the fixed build keeps the header, timeline, reused rows, tab bar, and media containers on classic Dim `#15202B` instead of pure black
- verified the app relaunches successfully after installing the clean final build
- full sideloaded Theos build passes
- `git diff --check` passes
- temporary hierarchy capture and forced-preference instrumentation were removed before commit

Fixes #29