### PR TITLE
(fix) Default the new in-app browser off under LiveContainer

### DIFF
--- a/src/Core/BHTManager.h
+++ b/src/Core/BHTManager.h
@@ -21,5 +21,6 @@
 + (NSString*)getDownloadingPercent:(float)progress;
 
 + (BOOL)isTwitterBranded;
++ (BOOL)isLiveContainer;
 
 @end

--- a/src/Core/BHTManager.m
+++ b/src/Core/BHTManager.m
@@ -5,6 +5,8 @@
 //  Created by BandarHelal.
 //
 
+#include <stdlib.h>
+
 #import "Core/BHTManager.h"
 #import "Core/BHTBundle.h"
 #import "Core/BHTSettings.h"
@@ -145,6 +147,20 @@
             isEqual:@"Twitter"];
     });
     return branded;
+}
+
+// LiveContainer runs a guest app inside its own process rather than installing
+// it, and exports the guest's redirected home directory to it. Both variables
+// come straight from LiveContainer's guest-side hooks (LC_HOME_PATH normally,
+// LP_HOME_PATH in LiveProcess mode), so checking for either is more durable
+// than matching on the guest's bundle path layout.
++ (BOOL)isLiveContainer {
+    static BOOL liveContainer = NO;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        liveContainer = getenv("LC_HOME_PATH") != NULL || getenv("LP_HOME_PATH") != NULL;
+    });
+    return liveContainer;
 }
 
 + (UIViewController*)BHTSettingsWithAccount:(TFNTwitterAccount*)twAccount {

--- a/src/Core/BHTSettings.m
+++ b/src/Core/BHTSettings.m
@@ -382,8 +382,11 @@ static NSDictionary<NSString*, NSDictionary*>* BHTSettingsPages(void) {
                     },
                     @{@"key": @"always_open_safari",
                       @"default": @NO},
+                    // X's new article webview does not work under
+                    // LiveContainer, so default it off there rather than
+                    // forcing the switch on for every guest install.
                     @{@"key": @"new_inapp_webview",
-                      @"default": @YES}
+                      @"default": @(![BHTManager isLiveContainer])}
                 ]
             },
             @"debug": @{


### PR DESCRIPTION
Fixes #39.

X's new article webview (`ios_in_app_article_webview_enabled`) doesn't work under
LiveContainer — links silently fail to load and "Open in Browser" errors out.
`new_inapp_webview` defaulted to `@YES` and the override replaces X's own decider in
both directions, so every LiveContainer install got broken links until the user
happened to find the beta toggle.

This makes the default environment-aware rather than forcing the switch on.
`boolForKey` only falls back to the default when nothing is stored, so anyone who
deliberately enabled it keeps their setting. Follows the existing computed default
used for `blue_launch_screen`.

**Detection**

```objc
liveContainer = getenv("LC_HOME_PATH") != NULL || getenv("LP_HOME_PATH") != NULL;
```

Both variables are exported into the guest process and used by LiveContainer's own
guest-side hooks (`TweakLoader/UIKit+GuestHooks.m`,
`LiveContainer/Tweaks/NSFileManager+GuestHooks.m`), which do exactly
`getenv(NSUserDefaults.isLiveProcess ? "LP_HOME_PATH" : "LC_HOME_PATH")` — hence
checking both. I originally tried matching on the guest bundle path and it was wrong;
the env vars are the durable signal.

**Testing**

Built and verified on device (iPhone 17 Pro Max, iOS 26.6, LiveContainer): with a
fresh data container the toggle now comes up disabled on its own and links open
correctly with no manual intervention. Non-LiveContainer behaviour is unchanged —
`getenv` returns NULL and the default stays `YES`.

Build was the tweak compiled against X 12.15 with the dylib swapped into the stock
6.5.0 IPA, so everything outside `BHTwitter.dylib` was byte-identical to the release.

Note `.github/workflows/build.yml` is `workflow_dispatch` only, so CI won't build this
PR automatically.

**Sequencing**

Worth flagging that this is quality-of-life behind #38: a new LiveContainer user on
6.5.0 hangs at the launch logo and never gets far enough to reach a working in-app
browser. #38 is the blocking bug.
