### PR TITLE
(fix) Fix startup hang under LiveContainer on X 12.15

### DIFF
--- a/src/Hooks/Launch.x
+++ b/src/Hooks/Launch.x
@@ -36,3 +36,33 @@ static UIColor* twitterColor(void) {
 
 
 %end
+
+
+// MARK: - LiveContainer startup hang (X 12.15+)
+//
+// X 12.15 gates boot on notification permission being *determined*:
+// BootViewController asks for authorization and waits for the
+// NotDetermined -> Denied/Authorized transition that normally arrives when the
+// user answers the system prompt and the app becomes active again.
+//
+// A LiveContainer guest can never satisfy that. -requestAuthorizationWithOptions:
+// fails instantly with granted=0 without ever presenting a prompt, and the status
+// stays NotDetermined, so the gate re-asks forever, its signed-out completion is
+// never invoked and the launch screen never clears -- a permanent hang on the
+// logo for any fresh, signed-out install.
+//
+// Reporting the permission as denied (which is the truthful state: a guest cannot
+// be granted it) lets boot proceed. Confirmed on X 12.15 / iOS 26.6: boot
+// completes in ~0.6s instead of hanging indefinitely.
+%hook UNNotificationSettings
+
+- (NSInteger)authorizationStatus {
+    NSInteger status = %orig;
+    if (status == 0 /* UNAuthorizationStatusNotDetermined */ &&
+        [BHTManager isLiveContainer]) {
+        return 1; // UNAuthorizationStatusDenied
+    }
+    return status;
+}
+
+%end


### PR DESCRIPTION
Fixes #38.

**Root cause — this is not a 6.5.0 regression, and not a NeoFreeBird bug.**

X 12.15 added a boot gate to `BootViewController`. `-[T1HostViewController viewBootViewController]`
builds it with `initWithSignedOutCompletion:signedInCompletion:`, and the call to
`viewSignedOutAnimated:` lives *inside* the signed-out completion block. In 12.15 that
completion is gated on notification permission becoming **determined** — the class gained a
new `-applicationDidBecomeActiveWithPendingPermission` method (absent in 12.9) that resumes
boot after the user answers the system prompt.

A LiveContainer guest can never satisfy that gate. `requestAuthorizationWithOptions:` returns
`granted=0` instantly **without ever presenting a prompt**, and the authorization status stays
`NotDetermined`. So the gate re-asks forever, the signed-out completion is never invoked, and
the launch screen never clears.

**The fix**

```objc
%hook UNNotificationSettings
- (NSInteger)authorizationStatus {
    NSInteger status = %orig;
    if (status == 0 /* NotDetermined */ && [BHTManager isLiveContainer]) {
        return 1; // Denied
    }
    return status;
}
%end
```

Gated on LiveContainer, so nothing changes for normal installs. `Denied` is the truthful state
— a guest cannot be granted the permission — and apps must already handle denial.

**How this was established**

Swapping `BHTwitter.dylib` between the two release IPAs isolates base app from tweak
(iPhone 17 Pro Max / iOS 26.6 / LiveContainer, fresh container, signed out):

| Base app | Tweak | Result |
|---|---|---|
| X 12.9  | 6.4.0 | works |
| X 12.9  | 6.5.0 | works |
| X 12.15 | 6.4.0 | **hangs** |
| X 12.15 | *empty stub dylib — no tweak code at all* | **hangs** |

The base version predicts the hang perfectly. I then ran an instrumented build that hooks the
launch path and draws a live trace on screen. It showed the main thread healthy the whole time
(a heartbeat kept ticking), boot stopping right after `_useViewController: BootViewController`,
and `UN requestAuthorization CALLED` → `UN completion FIRED granted=0` repeating forever while
`viewSignedOutAnimated:` was never reached.

Forcing the status to `Denied` under the same conditions:

```
0.51s UNSettings authorizationStatus real=0 -> forcing 1(Denied)
0.55s viewSignedOutAnimated: ENTER          <- previously never reached
0.55s makeOnboardingVC ENTER (completion=yes)
0.56s _useViewController: TFNNavigationController
```

Boot completes in ~0.6s and the login page renders. Verified again with the full tweak built
from this branch, not just the probe.

**Note on branching:** this is stacked on #41 because it uses the `[BHTManager isLiveContainer]`
helper introduced there, so this PR contains both commits. Merging this alone covers both; if
you merge #41 first this rebases cleanly.
