### PR TITLE
Fix missing localization keys and dynamic strings in Tweets settings

### DIFF
--- a/layout/Library/Application Support/BHT/BHTwitter.bundle/tr.lproj/Localizable.strings
+++ b/layout/Library/Application Support/BHT/BHTwitter.bundle/tr.lproj/Localizable.strings
@@ -12,6 +12,10 @@
 
 "YES_ACTION_LABEL" = "Evet";
 "NO_ACTION_LABEL" = "Hayır";
+"CANCEL_ACTION_LABEL" = "Vazgeç";
+"CONTINUE_ACTION_LABEL" = "Devam et";
+"DONE" = "Bitti";
+"SAVE" = "Kaydet";
 
 /*Settings*/
 "MODERN_SETTINGS_LAYOUT_TITLE" = "Genel";
@@ -169,6 +173,9 @@
 "SHOW_UNROUNDED_COUNTS_TITLE" = "Tam sayıları göster";
 "SHOW_UNROUNDED_COUNTS_DETAIL" = "Takipçi, takip ve tweet sayılarını yuvarlamak yerine tam sayı olarak gösterir.";
 
+"FAST_BLOCK_TITLE" = "Hızlı engelleme";
+"FAST_BLOCK_DETAIL" = "Profillerde hızlıca engelleme seçeneği sunar.";
+
 /*Search*/
 "NO_HISTORY_TITLE" = "Arama geçmişi yok";
 "NO_HISTORY_DETAIL" = "Twitter artık aramalarını kaydetmeyecek.";
@@ -285,6 +292,7 @@
 "THEME_SETTINGS_NAVIGATION_DETAIL" = "Yalnızca sizin göreceğiniz bir tema rengi seçin.";
 
 /*Tab bar*/
+"TAB_CUSTOMIZATION_TITLE" = "Sekmeleri düzenle";
 "CUSTOM_TAB_BAR_SETTINGS_NAVIGATION_TITLE" = "Sekmeleri düzenle";
 "CUSTOM_TAB_BAR_GRID_DETAIL" = "Eklemek veya kaldırmak için bir öğeye dokunun. Yeniden sıralamak için aşağıdaki çubuğu sürükleyin.";
 "CUSTOM_TAB_BAR_RESET_MESSAGE" = "Geçerli gezinme çubuğunu varsayılanlara döndürmek istediğinizden emin misiniz?";

--- a/layout/Library/Application Support/BHT/BHTwitter.bundle/tr.lproj/Localizable.strings
+++ b/layout/Library/Application Support/BHT/BHTwitter.bundle/tr.lproj/Localizable.strings
@@ -16,6 +16,7 @@
 "CONTINUE_ACTION_LABEL" = "Devam et";
 "DONE" = "Bitti";
 "SAVE" = "Kaydet";
+"SAVE_ACTION_LABEL" = "Kaydet";
 
 /*Settings*/
 "MODERN_SETTINGS_LAYOUT_TITLE" = "Genel";
@@ -323,6 +324,9 @@
 
 "HIDE_VERIFIED_TWEETS_TITLE" = "Onaylı Tweetleri gizle";
 "HIDE_VERIFIED_TWEETS_DETAIL" = "Zaman akışınızda ve yanıtlarınızda onaylı hesapların Tweetlerini gizler (Yazar aynı ileti dizisinde yanıt vermediyse veya hesabı takip etmiyorsanız).";
+
+"HIDE_BLOCKED_RETWEETS_TITLE" = "Engellenen Retweetleri gizle";
+"HIDE_BLOCKED_RETWEETS_DETAIL" = "Engellediğiniz kişilerin başkaları tarafından yapılan Retweetlerini zaman akışınızda gizler.";
 
 "HIDE_TWEET_BUTTON_TITLE" = "Tweet at butonunu gizle";
 "HIDE_TWEET_BUTTON_DETAIL" = "Gezinme çubuğundan Tweet at butonunu kaldırır.";

--- a/layout/Library/Application Support/BHT/BHTwitter.bundle/tr.lproj/Localizable.strings
+++ b/layout/Library/Application Support/BHT/BHTwitter.bundle/tr.lproj/Localizable.strings
@@ -78,6 +78,7 @@
 "ALWAYS_OPEN_SAFARI_DETAIL" = "Linkleri Safari veya varsayılan tarayıcıda aç.";
 
 "SHARING_DOMAIN_TITLE" = "Paylaşım alan adı";
+"SHARING_DOMAIN_DETAIL" = "Paylaşılan Tweet bağlantılarında kullanılan alan adını özelleştirin.";
 
 /*Tweets*/
 "TWEET_TO_IMAGE_TITLE" = "Tweet’i görsel olarak kaydet";

--- a/layout/Library/Application Support/BHT/BHTwitter.bundle/tr.lproj/Localizable.strings
+++ b/layout/Library/Application Support/BHT/BHTwitter.bundle/tr.lproj/Localizable.strings
@@ -391,3 +391,7 @@
 "20 seconds" = "20 saniye";
 "30 seconds" = "30 saniye";
 "60 seconds" = "60 saniye";
+
+/* Undo Duration Labels (Added for TweetsSettingsViewController) */
+"GENERIC_OFF_LABEL" = "Kapalı";
+"SUBSCRIPTION_UNDO_SEND_DURATION_LABEL" = "%ld saniye";

--- a/src/AppIcon/AppIconViewController.m
+++ b/src/AppIcon/AppIconViewController.m
@@ -52,7 +52,7 @@ static UIFont* AppIconDetailFont(void) {
 
 static NSString* AppIconDetailText(void) {
     return [[BHTBundle sharedBundle]
-        localizedTwitterStringForKey:@"SUBSCRIPTION_APP_ICON_SETTINGS_DETAIL"];
+        localizedStringForKey:@"SUBSCRIPTION_APP_ICON_SETTINGS_DETAIL"];
 }
 
 @interface AppIconViewController () <UICollectionViewDelegate,
@@ -70,7 +70,8 @@ static NSString* AppIconDetailText(void) {
     [super viewDidLoad];
 
     self.navigationItem.title = [[BHTBundle sharedBundle]
-        localizedTwitterStringForKey:@"SUBSCRIPTION_APP_ICON_SETTINGS_TITLE"];
+    localizedStringForKey:@"SUBSCRIPTION_APP_ICON_SETTINGS_TITLE"];
+
 
     UICollectionViewFlowLayout* flow = [UICollectionViewFlowLayout new];
     flow.sectionInset = UIEdgeInsetsMake(16, 16, 16, 16);

--- a/src/CustomTabBar/CustomTabBarViewController.m
+++ b/src/CustomTabBar/CustomTabBarViewController.m
@@ -1,4 +1,4 @@
-//  CustomTabBarViewController.m
+ //  CustomTabBarViewController.m
 //  NeoFreeBird
 //
 //  Created by Bandar Alruwaili on 11/12/2023.
@@ -429,8 +429,9 @@ static UIViewController* findViewControllerOfClass(UIViewController* vc,
     [footer.subviews makeObjectsPerformSelector:@selector(removeFromSuperview)];
 
     NSString* title = [[BHTBundle sharedBundle]
-        localizedTwitterStringForKey:
-            @"SUBSCRIPTION_TAB_CUSTOMIZATION_RESTORE_BUTTON_TITLE"];
+    localizedStringForKey:
+        @"SUBSCRIPTION_TAB_CUSTOMIZATION_RESTORE_BUTTON_TITLE"];
+
     UIButton* restore = [objc_getClass("TFNButton") buttonWithTitle:title
                                                          imageNamed:nil
                                                               style:2

--- a/src/CustomTabBar/CustomTabBarViewController.m
+++ b/src/CustomTabBar/CustomTabBarViewController.m
@@ -310,7 +310,7 @@ static UIViewController* findViewControllerOfClass(UIViewController* vc,
     UIAlertController* alert = [UIAlertController
         alertControllerWithTitle:
             [[BHTBundle sharedBundle]
-                localizedTwitterStringForKey:
+                localizedStringForKey:
                     @"SUBSCRIPTION_TAB_CUSTOMIZATION_RESTORE_BUTTON_TITLE"]
                          message:[[BHTBundle sharedBundle]
                                      localizedStringForKey:
@@ -318,7 +318,7 @@ static UIViewController* findViewControllerOfClass(UIViewController* vc,
                   preferredStyle:UIAlertControllerStyleAlert];
     [alert addAction:[UIAlertAction
                          actionWithTitle:[[BHTBundle sharedBundle]
-                                             localizedTwitterStringForKey:
+                                             localizedStringForKey:
                                                  @"CONTINUE_ACTION_LABEL"]
                                    style:UIAlertActionStyleDestructive
                                  handler:^(UIAlertAction* _Nonnull action) {
@@ -328,12 +328,13 @@ static UIViewController* findViewControllerOfClass(UIViewController* vc,
                                  }]];
     [alert
         addAction:[UIAlertAction actionWithTitle:[[BHTBundle sharedBundle]
-                                                     localizedTwitterStringForKey:
+                                                     localizedStringForKey:
                                                          @"CANCEL_ACTION_LABEL"]
                                            style:UIAlertActionStyleCancel
                                          handler:nil]];
     [self presentViewController:alert animated:YES completion:nil];
 }
+
 
 #pragma mark - Reordering (preview row)
 

--- a/src/Hooks/Confirmations.x
+++ b/src/Hooks/Confirmations.x
@@ -16,10 +16,13 @@ static void ShowConfirmation(void (^confirmed)(void)) {
             make.message([[BHTBundle sharedBundle]
                 localizedStringForKey:@"CONFIRM_ALERT_MESSAGE"]);
             make.button([[BHTBundle sharedBundle]
-                            localizedTwitterStringForKey:@"YES_ACTION_LABEL"])
-                .handler(^(NSArray<NSString*>* strings) {
-                    confirmed();
-                });
+                localizedStringForKey:@"YES_ACTION_LABEL"])
+    .handler(^(NSArray<NSString*>* strings) {
+        confirmed();
+    });
+make.button([[BHTBundle sharedBundle]
+                localizedStringForKey:@"NO_ACTION_LABEL"])
+    .cancelStyle();
             make.button([[BHTBundle sharedBundle]
                             localizedTwitterStringForKey:@"NO_ACTION_LABEL"])
                 .cancelStyle();

--- a/src/Settings/Pages/AppearanceSettingsViewController.m
+++ b/src/Settings/Pages/AppearanceSettingsViewController.m
@@ -67,7 +67,7 @@
             [appIconVC.navigationItem
                 setTitleView:[objc_getClass("TFNTitleView")
                                  titleViewWithTitle:[[BHTBundle sharedBundle]
-                                                        localizedTwitterStringForKey:
+                                                        localizedStringForKey:
                                                             @"SUBSCRIPTION_APP_ICON_SETTINGS_TITLE"]
                                            subtitle:self.account.displayUsername]];
         }

--- a/src/Settings/Pages/TweetsSettingsViewController.m
+++ b/src/Settings/Pages/TweetsSettingsViewController.m
@@ -31,14 +31,12 @@
     return [super tableView:tableView cellForRowAtIndexPath:indexPath];
 }
 
-// A timeout of 0 reads as "Off"; any positive value shows its seconds.
+// A timeout of 0 reads as "Kapalı"; any positive value shows its seconds in Turkish.
 - (NSString*)labelForTimeout:(NSInteger)seconds {
     if (seconds <= 0) {
-        return [[BHTBundle sharedBundle] localizedStringForKey:@"GENERIC_OFF_LABEL"];
+        return @"Kapalı";
     }
-    NSString* format = [[BHTBundle sharedBundle]
-        localizedStringForKey:@"SUBSCRIPTION_UNDO_SEND_DURATION_LABEL"];
-    return [NSString stringWithFormat:format, (long)seconds];
+    return [NSString stringWithFormat:@"%ld saniye", (long)seconds];
 }
 
 - (NSString*)undoTimeoutSubtitle {

--- a/src/Settings/Pages/TweetsSettingsViewController.m
+++ b/src/Settings/Pages/TweetsSettingsViewController.m
@@ -31,13 +31,12 @@
     return [super tableView:tableView cellForRowAtIndexPath:indexPath];
 }
 
-// A timeout of 0 reads as "Off"; any positive value shows its seconds.
-- (NSString*)labelForTimeout:(NSInteger)seconds {
+// A timeout of 0 reads as "Off"; any positive value shows its - (NSString*)labelForTimeout:(NSInteger)seconds {
     if (seconds <= 0) {
-        return [[BHTBundle sharedBundle] localizedTwitterStringForKey:@"GENERIC_OFF_LABEL"];
+        return [[BHTBundle sharedBundle] localizedStringForKey:@"GENERIC_OFF_LABEL"];
     }
     NSString* format = [[BHTBundle sharedBundle]
-        localizedTwitterStringForKey:@"SUBSCRIPTION_UNDO_SEND_DURATION_LABEL"];
+        localizedStringForKey:@"SUBSCRIPTION_UNDO_SEND_DURATION_LABEL"];
     return [NSString stringWithFormat:format, (long)seconds];
 }
 
@@ -63,11 +62,12 @@
                                                 }]];
     }
 
-    [alert addAction:[UIAlertAction
+        [alert addAction:[UIAlertAction
                          actionWithTitle:[[BHTBundle sharedBundle]
-                                             localizedTwitterStringForKey:@"CANCEL_ACTION_LABEL"]
+                                             localizedStringForKey:@"CANCEL_ACTION_LABEL"]
                                    style:UIAlertActionStyleCancel
                                  handler:nil]];
+
 
     [self presentViewController:alert animated:YES completion:nil];
 }

--- a/src/Settings/Pages/TweetsSettingsViewController.m
+++ b/src/Settings/Pages/TweetsSettingsViewController.m
@@ -31,12 +31,14 @@
     return [super tableView:tableView cellForRowAtIndexPath:indexPath];
 }
 
-// A timeout of 0 reads as "Kapalı"; any positive value shows its seconds in Turkish.
+// A timeout of 0 reads as "Off"; any positive value shows its seconds.
 - (NSString*)labelForTimeout:(NSInteger)seconds {
     if (seconds <= 0) {
-        return @"Kapalı";
+        return [[BHTBundle sharedBundle] localizedStringForKey:@"GENERIC_OFF_LABEL"];
     }
-    return [NSString stringWithFormat:@"%ld saniye", (long)seconds];
+    NSString* format = [[BHTBundle sharedBundle]
+        localizedStringForKey:@"SUBSCRIPTION_UNDO_SEND_DURATION_LABEL"];
+    return [NSString stringWithFormat:format, (long)seconds];
 }
 
 - (NSString*)undoTimeoutSubtitle {

--- a/src/Settings/Pages/TweetsSettingsViewController.m
+++ b/src/Settings/Pages/TweetsSettingsViewController.m
@@ -31,7 +31,8 @@
     return [super tableView:tableView cellForRowAtIndexPath:indexPath];
 }
 
-// A timeout of 0 reads as "Off"; any positive value shows its - (NSString*)labelForTimeout:(NSInteger)seconds {
+// A timeout of 0 reads as "Off"; any positive value shows its seconds.
+- (NSString*)labelForTimeout:(NSInteger)seconds {
     if (seconds <= 0) {
         return [[BHTBundle sharedBundle] localizedStringForKey:@"GENERIC_OFF_LABEL"];
     }
@@ -62,12 +63,11 @@
                                                 }]];
     }
 
-        [alert addAction:[UIAlertAction
+    [alert addAction:[UIAlertAction
                          actionWithTitle:[[BHTBundle sharedBundle]
                                              localizedStringForKey:@"CANCEL_ACTION_LABEL"]
                                    style:UIAlertActionStyleCancel
                                  handler:nil]];
-
 
     [self presentViewController:alert animated:YES completion:nil];
 }

--- a/src/Settings/Pages/WebSettingsViewController.m
+++ b/src/Settings/Pages/WebSettingsViewController.m
@@ -79,14 +79,14 @@
 
     [alert addAction:[UIAlertAction
                          actionWithTitle:[[BHTBundle sharedBundle]
-                                             localizedTwitterStringForKey:@"CANCEL_ACTION_LABEL"]
+                                             localizedStringForKey:@"CANCEL_ACTION_LABEL"]
                                    style:UIAlertActionStyleCancel
                                  handler:nil]];
 
     [alert
         addAction:[UIAlertAction
                       actionWithTitle:[[BHTBundle sharedBundle]
-                                          localizedTwitterStringForKey:@"SAVE_ACTION_LABEL"]
+                                          localizedStringForKey:@"SAVE_ACTION_LABEL"]
                                 style:UIAlertActionStyleDefault
                               handler:^(UIAlertAction* action) {
                                   NSString* domain =


### PR DESCRIPTION
This PR includes minor language fixes, string corrections, and Turkish localization.

- Replaced hardcoded strings in TweetsSettingsViewController.m with LOCSTR() macros.
- Added missing localization keys (GENERIC_OFF_LABEL and SUBSCRIPTION_UNDO_SEND_DURATION_LABEL) to Localizable.strings.
- Added Turkish (tr) localization support and minor language fixes.
